### PR TITLE
fix output for print spooler disabled case

### DIFF
--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -299,7 +299,7 @@ If ((Get-WMIObject win32_service -Filter "Name='spooler'").StartMode -eq 'Disabl
     $output += "If mitigation existed before, it has been removed. It is not necessary."
 
     # Exit Point
-    Write-Output "outputLog=$output|compatibleOs=$compatibleOs|originalPnpDisabledValue=$originalPnpDisabledValue|pnpVulnerableFeaturesDisabled=$pnpDisabled|mitigationApplied=$mitigationApplied|patchApplied=$patchApplied|protected=1"
+    Write-Output "outputLog=$output|compatibleOs=$compatibleOs|originalPnpDisabledValue=$originalPnpDisabledValue|pnpVulnerableFeaturesDisabled=$pnpDisabled|mitigationApplied=0|patchApplied=$patchApplied|protected=1"
     Return
 }
 


### PR DESCRIPTION
Realized that 'mitigationApplied' should always be 0 when print spooler is disabled. Remove-Mitigation is called right before the output. Could have ended up with incorrect output.