### PR TITLE
Forgot to reapply mitigation upon patch failure and some missing output values

### DIFF
--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -34,6 +34,10 @@ $mitigationApplied = 0
 $patchApplied = 0
 # If Point and Print vulnerable features are disabled according to registry
 $pnpDisabled = 0
+# If Machine is protected from the vulnerability in some manner
+$protected = 0
+# If machine has restrictDriverInstallationToAdministrators enabled in registry
+$restrictDriverInstallation = 0
 
 # Will hold saved pnp reg settings state if exists
 $originalPnpDisabledValue = ''
@@ -334,35 +338,32 @@ If (!$compatibleOs) {
 If (!$patchApplied) {
     # Remove mitigation before install to avoid installation errors, since the mitigation involves removing permission from SYSTEM
     Remove-Mitigation
+    $mitigationApplied = 0
+
     $output += "Removed mitigation temporarily during installation."
     $output += Install-Patch
 
     # If the patch was sucessfully installed
     If ($output -like "*!SUCCESS*") {
         $patchApplied = 1
-
-        # Is the mitigation applied at this point?
-        If (!(Test-MitigationApplied)) {
-            $mitigationApplied = 0
-        }
+    } Else {
+        $patchApplied = 0
     }
 }
 
-# If patch is installed and driver installation restricted to admins
-If ($patchApplied -and $restrictDriverInstallation -eq 1) {
-    $output += "Patch is installed and driver installation is restricted to administrators. Not Vulnerable!"
-    $protected = 1
-} ElseIf ($patchApplied) {
-    # Patch is installed but driver installation is not restricted
-    # Normalize $restrictDriverInstallation for output
-    $restrictDriverInstallation = 0
+If ($patchApplied) {
+    # Patch is installed
+    If ($restrictDriverInstallation -eq 1) {
+        # and driver installation restricted to admins, so protected
+        $output += "Patch is installed and driver installation is restricted to administrators. Not Vulnerable!"
+        $protected = 1
+    } ElseIf (!$pnpDisabled) {
+        # pnp vulnerable features are enabled. Need to disable them. If that fails, need to reapply ACL
+        $protected = 0
 
-    If ($pnpDisabled) {
-        # if patch is installed and pnp is disabled, can remove mitigation! Machine is not vulnerable.
-        Remove-Mitigation
-        $output += "Patch is applied and PnP is disabled! Mitigation is not necessary. Removed if it existed."
-        $mitigationApplied = 0
-    } Else {
+        # Normalize $restrictDriverInstallation as it could be a non-integer value
+        $restrictDriverInstallation = 0
+
         # It is possible to make this check more thorough if setting these reg keys to 0 causes issues.
         # Machine is still not remotely exploitable if machine is:
         # not DC, no folders are shared, no printers are shared, firewall is enabled, and firewall is blocking 135, 139, and 445
@@ -373,14 +374,31 @@ If ($patchApplied -and $restrictDriverInstallation -eq 1) {
         Set-ItemProperty -Path $PnpRegPath -Name "UpdatePromptSettings" -EA 0 -Value 0
         $output += "Pnp reg keys existed and were enabled, so set them to 0"
 
-        $pnpDisabled = Get-PnpStatus
-    }
+        # Check one last time...
+        If (Get-PnpStatus) {
+            # pnp vulnerable features are disabled and patch is installed!
+            $pnpDisabled = 1
+            $protected = 1
+        } Else {
+            $pnpDisabled = 0
 
-    # At this point, the patch is applied, and the pnp features are disabled, the machine is protected no matter what.
-    $protected = 1
+            # pnp vulnerable features are still enabled so reapply mitigation
+            $output += Apply-Mitigation
+            If (Test-MitigationApplied) {
+                $mitigationApplied = 1
+                $protected = 1
+            }
+        }
+    } Else {
+        # Mitigation was removed earlier, so no need to remove again
+        # Normalize $restrictDriverInstallation as it could be a non-integer value
+        $restrictDriverInstallation = 0
+    }
 } Else {
-    # $restrictDriverInstallation does not equal 1, so normalize to 0 for output
-    $restrictDriverInstallation = 0
+    # Patch is still not installed so reapply mitigation
+    $output += Apply-Mitigation
+    $mitigationApplied = 1
+    $protected = 1
 }
 
 Write-Output "outputLog=$output|compatibleOs=$compatibleOs|originalPnpDisabledValue=$originalPnpDisabledValue|pnpVulnerableFeaturesDisabled=$pnpDisabled|mitigationApplied=$mitigationApplied|patchApplied=$patchApplied|protected=$protected|restrictDriverInstallation=$restrictDriverInstallation"


### PR DESCRIPTION
- Set default value for `$protected` in 'init vars' section
- Set default value for `$restrictDriverInstallation` in 'init vars' section
- Simplify control flow at very end, ensuring that proper values for outputs are set in each branch, and also ensuring that ACL is reapplied if:
  - patch is not installed 
  - pnp vulnerable features are still enabled