### PR TITLE
Fixed name of Get-PnpStatus as it was hard to reason about

### DIFF
--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -236,7 +236,7 @@ function Install-Patch {
     Return $out -join "`n"
 }
 
-function Get-PnpStatus {
+function Get-PnpFeaturesDisabled {
     $pnp1Enabled = (Get-ItemProperty -Path $PnpRegPath -Name "NoWarningNoElevationOnInstall" -EA 0).NoWarningNoElevationOnInstall
     $pnp2Enabled = (Get-ItemProperty -Path $PnpRegPath -Name "UpdatePromptSettings" -EA 0).UpdatePromptSettings
 
@@ -265,7 +265,7 @@ If ($compatibleOs -and (Get-HotFix -Id $kb -EA 0)) {
 }
 
 # If bad Point and Print settings are disabled according to registry
-$pnpDisabled = Get-PnpStatus
+$pnpDisabled = Get-PnpFeaturesDisabled
 
 # If RestrictDriverInstallationToAdministrators is true
 $restrictDriverInstallation = (Get-ItemProperty -Path $PnpRegPath -Name "RestrictDriverInstallationToAdministrators" -EA 0).RestrictDriverInstallationToAdministrators
@@ -377,7 +377,7 @@ If ($patchApplied) {
         $output += "Pnp reg keys existed and were enabled, so set them to 0"
 
         # Check one last time...
-        If (Get-PnpStatus) {
+        If (Get-PnpFeaturesDisabled) {
             # pnp vulnerable features are disabled and patch is installed!
             $pnpDisabled = 1
             $protected = 1


### PR DESCRIPTION
Fixed name of Get-PnpStatus as it was hard to reason about. It was basically named backwards, requiring mental gymnastics to understand what it was doing. Changed name to `Get-PnpFeaturesDisabled`