### PR TITLE
Add SSUs and Cumulatives, hash check file downloads,

### DIFF
--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -125,14 +125,17 @@ Switch ($os) {
         $ssu =      'KB5004378'
         $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004378-x64_e295e0dfb732d1d4712c6aa5ac72aa28a7067359.msu'
     }
-    # Windows 8.1 doesn't have any SSU
     '8.1_32-bit' {
         $kb =       'KB5004958';
         $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x86_ee2308010d7605cad53e19a1bc762d85d044d88d.msu'
+        $ssu =      'KB5001403'
+        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8.1-kb5001403-x86_c59ac03777801436fa01dbf341f164a709ce8f8a.msu'
     }
     '8.1_64-bit' {
         $kb =       'KB5004958';
         $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x64_8b73440b9c53bcea2660d9409b6ad3920f104cd2.msu'
+        $ssu =      'KB5001403'
+        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8.1-kb5001403-x64_7f15c4b281f38d43475abb785a32dbaf0355bad5.msu'
     }
     '2012' {
         $kb =       'KB5004960';

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -587,7 +587,7 @@ If (!$patchApplied) {
     Remove-Mitigation
     $mitigationApplied = 0
 
-    $output += "outputLog=$($output -join ' `n')ation temporarily during installation."
+    $output += "Removed mitigation temporarily during installation."
     $output += Install-Patch -PatchKb $cumulativeKb -PatchUrl $cumulativeUrl
 
     # If the patch was sucessfully installed

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -610,12 +610,15 @@ If ($patchApplied) {
             }
         }
     } Else {
-        # Mitigation was removed earlier, so no need to remove again
         # Normalize $restrictDriverInstallation as it could be a non-integer value
         $restrictDriverInstallation = 0
 
+        # Ensure mitigation is not in place
+        Remove-Mitigation
+        $mitigationApplied = 0
+
         # Patch is applied, ACL mitigation is removed, pnp settings are disabled, all good!
-        $output += "Patch was already applied and vulnerable pnp settings are disabled. Not vulnerable."
+        $output += "Patch was already applied and vulnerable pnp settings are disabled. Not vulnerable. Removed ACL mitigation if existed."
         $protected = 1
     }
 } Else {

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -318,34 +318,42 @@ function Apply-Mitigation {
     return $out -join "`n"
 }
 
-function Install-Patch {
+function Install-Patch (
+    # the KB number of the patch you'd like to install
+    [string]
+    $PatchKb
+
+    # the URL to download the patch you'd like to install
+    [string]
+    $PatchUrl
+) {
     [array]$out
 
     If (!(Test-Path -Path $patchDir -PathType Container)) {
         New-Item $patchDir -ItemType Directory | Out-Null
     }
 
-    $out += "Detected $($kb) is missing. Downloading/installing $($kb)."
+    $out += "Detected $($PatchKb) is missing. Downloading/installing $($PatchKb)."
 
-    If (!$url) {
+    If (!$PatchUrl) {
         $out += "!Failed: Unsupported OS! Download URL was empty!"
         Return $out -join "`n"
     }
 
-    $out += "Downloading $($kb)..."
+    $out += "Downloading $($PatchKb)..."
 
     Try {
         [Net.ServicePointManager]::SecurityProtocol = [Enum]::ToObject([Net.SecurityProtocolType], 3072)
-        (New-Object System.Net.WebClient).DownloadFile($url,"$patchDir\$kb.msu")
+        (New-Object System.Net.WebClient).DownloadFile($PatchUrl,"$patchDir\$PatchKb.msu")
     } Catch {
         # Couldn't download. Exit early.
-        $out += "There was an error downloading the patch from $url -> $Error"
+        $out += "There was an error downloading the patch from $PatchUrl -> $Error"
         Return $out -join "`n"
     }
 
     Try {
-        $out += "Installing $($kb)..."
-        Start-Process -FilePath wusa.exe -ArgumentList """$patchDir\$kb.msu"" /quiet /norestart /log:""$patchDir\$($kb)-InstallLog.evt""" -Wait
+        $out += "Installing $($PatchKb)..."
+        Start-Process -FilePath wusa.exe -ArgumentList """$patchDir\$PatchKb.msu"" /quiet /norestart /log:""$patchDir\$($PatchKb)-InstallLog.evt""" -Wait
     } Catch {
         # Installation failed.
         $out += "Installation failed."
@@ -353,9 +361,9 @@ function Install-Patch {
 
     # Clean up downloaded patch
     # TODO: only delete file after successful installation to avoid re-downloading. Would need to hash check.
-    Remove-Item -Path "$patchDir\$kb.msu" -Force
+    Remove-Item -Path "$patchDir\$PatchKb.msu" -Force
 
-    If (Get-HotFix -Id $kb -EA 0) {
+    If (Get-HotFix -Id $PatchKb -EA 0) {
         $out += "!SUCCESS: The patch was successfully installed."
     } Else {
         $out += "!FAILED: Patch installation failed."
@@ -471,7 +479,7 @@ If (!$patchApplied) {
     $mitigationApplied = 0
 
     $output += "Removed mitigation temporarily during installation."
-    $output += Install-Patch
+    $output += Install-Patch -PatchKb $kb -PatchUrl $url
 
     # If the patch was sucessfully installed
     If ($output -like "*!SUCCESS*") {

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -131,7 +131,7 @@ Switch ($os) {
         $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x86_ee2308010d7605cad53e19a1bc762d85d044d88d.msu'
     }
     '8.1_64-bit' {
-        $kb =       'KB5004954';
+        $kb =       'KB5004958';
         $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x64_8b73440b9c53bcea2660d9409b6ad3920f104cd2.msu'
     }
     '2012' {

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -327,33 +327,69 @@ function Install-Patch (
     [string]
     $PatchUrl
 ) {
+    # Make sure we have everything we need
+    If (!$PatchUrl) {
+        $out += "!Failed: Download URL not provided!"
+        Return $out -join "`n"
+    } ElseIf (!$PatchKb) {
+        $out += "!Failed: KB number not provided!"
+        Return $out -join "`n"
+    }
+
     [array]$out
     $patchPath = "$patchDir\$PatchKb.msu"
+    $hashFromUrl = $PatchUrl.split('_')[1].substring(0,40)
+    $skipDownload = 0
 
     If (!(Test-Path -Path $patchDir -PathType Container)) {
         New-Item $patchDir -ItemType Directory | Out-Null
     }
 
-    $out += "Detected $($PatchKb) is missing. Downloading/installing $($PatchKb)."
+    $out += "Detected $($PatchKb) is missing. Installing $($PatchKb)."
 
-    If (!$PatchUrl) {
-        $out += "!Failed: Unsupported OS! Download URL was empty!"
-        Return $out -join "`n"
+    # Check if file already exists and hash matches
+    If (Test-Path -Path $patchPath) {
+        # File exists so check hash
+        $fileHash = (Get-FileHash -Path $patchPath -Algorithm 'SHA1').Hash
+        If ($hashFromUrl -eq $fileHash) {
+            # Hash matches, can skip download
+            $skipDownload = 1
+            $out += "$patchKb file already exists and the hash checks out. Will not redownload."
+        } Else {
+            # File exists, but hash does not match. Delete file.
+            Remove-Item -Path $patchPath -Force
+            $out += "$patchKb installation file existed, but the hash did not match. Deleted file. Will redownload."
+        }
     }
 
-    $out += "Downloading $($PatchKb)..."
+    # If we need to download
+    If (!$skipDownload) {
+        $out += "Downloading $($PatchKb)..."
 
-    Try {
-        [Net.ServicePointManager]::SecurityProtocol = [Enum]::ToObject([Net.SecurityProtocolType], 3072)
-        (New-Object System.Net.WebClient).DownloadFile($PatchUrl, $patchPath)
-    } Catch {
-        # Couldn't download. Exit early.
-        $out += "There was an error downloading the patch from $PatchUrl -> $Error"
-        Return $out -join "`n"
+        Try {
+            [Net.ServicePointManager]::SecurityProtocol = [Enum]::ToObject([Net.SecurityProtocolType], 3072)
+            (New-Object System.Net.WebClient).DownloadFile($PatchUrl, $patchPath)
+        } Catch {
+            # Couldn't download. Exit early.
+            $out += "There was an error downloading the patch from $PatchUrl -> $Error"
+            Return $out -join "`n"
+        }
+
+        # Newly downloaded, so check hash
+        $fileHash = (Get-FileHash -Path $patchPath -Algorithm 'SHA1').Hash
+
+        # Check hash
+        If ($hashFromUrl -eq $fileHash) {
+            $out += "$patchKb file downloaded successfully. Hash check succeeded after download."
+        } Else {
+            # File exists, but hash does not match. Delete file. And exit early.
+            Remove-Item -Path $patchPath -Force
+            $out += "!Failed: $patchKb installation failed. The installation file was not successfully downloaded."
+            Return $out -join "`n"
+        }
     }
 
-    # TODO: Check hash here before proceeding...........
-
+    # Install patch
     Try {
         $out += "Installing $($PatchKb)..."
         Start-Process -FilePath wusa.exe -ArgumentList """$patchPath"" /quiet /norestart /log:""$patchDir\$($PatchKb)-InstallLog.evt""" -Wait
@@ -362,6 +398,7 @@ function Install-Patch (
         $out += "Installation failed."
     }
 
+    # If patch installed successfully
     If (Get-HotFix -Id $PatchKb -EA 0) {
         # Clean up downloaded patch
         Remove-Item -Path $patchPath -Force

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -364,9 +364,9 @@ function Install-Patch (
     Remove-Item -Path "$patchDir\$PatchKb.msu" -Force
 
     If (Get-HotFix -Id $PatchKb -EA 0) {
-        $out += "!SUCCESS: The patch was successfully installed."
+        $out += "!SUCCESS: $PatchKb was successfully installed."
     } Else {
-        $out += "!FAILED: Patch installation failed."
+        $out += "!FAILED: $PatchKb installation failed."
     }
 
     Return $out -join "`n"
@@ -474,6 +474,19 @@ If (!$compatibleOs) {
 
 # If patch is not installed, install it
 If (!$patchApplied) {
+    If ($ssu) {
+        # SSU exists for this OS, let's see if it's already installed and if not, install it
+        If (!(Get-HotFix -Id $ssu -EA 0)) {
+            $ssuOutput = Install-Patch -PatchKb $ssu -PatchUrl $ssuUrl
+        } Else {
+            $ssuOutput = "SSU update $ssu is already installed."
+        }
+    } Else {
+        $ssuOutput = "Skipping SSU installation, no new SSU exists for this OS."
+    }
+
+    # We don't care whether SSU installation succeeds, so no check for success. We still want to try installing the patch either way
+
     # Remove mitigation before install to avoid installation errors, since the mitigation involves removing permission from SYSTEM
     Remove-Mitigation
     $mitigationApplied = 0
@@ -487,6 +500,8 @@ If (!$patchApplied) {
     } Else {
         $patchApplied = 0
     }
+
+    $output += $ssuOutput
 }
 
 If ($patchApplied) {

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -21,7 +21,7 @@ $patchDir = "$ltPath\Patching"
 <# ------------------------ Init vars ------------------------------------- #>
 # $output is an array that will hold various messages throughout the mitigation process
 # and will eventually be returned as a single string joined together
-[array]$output
+$output = @()
 
 # $os will be the os name + architecture (when necessary)
 $os = ''
@@ -477,7 +477,7 @@ If ((Get-WMIObject win32_service -Filter "Name='spooler'").StartMode -eq 'Disabl
     $output += "If mitigation existed before, it has been removed. It is not necessary."
 
     # Exit Point
-    Write-Output "outputLog=$output|compatibleOs=$compatibleOs|originalPnpDisabledValue=$originalPnpDisabledValue|pnpVulnerableFeaturesDisabled=$pnpDisabled|mitigationApplied=0|patchApplied=$patchApplied|protected=1"
+    Write-Output "outputLog=$($output -join '`n')|compatibleOs=$compatibleOs|originalPnpDisabledValue=$originalPnpDisabledValue|pnpVulnerableFeaturesDisabled=$pnpDisabled|mitigationApplied=0|patchApplied=$patchApplied|protected=1"
     Return
 }
 
@@ -492,7 +492,7 @@ If ($excludeFromMitigation -eq 1) {
     }
 
     # Exit Point
-    Write-Output "outputLog=$output|compatibleOs=$compatibleOs|originalPnpDisabledValue=$originalPnpDisabledValue|pnpVulnerableFeaturesDisabled=$pnpDisabled|mitigationApplied=$mitigationApplied|patchApplied=$patchApplied|protected=$protected"
+    Write-Output "outputLog=$($output -join '`n')|compatibleOs=$compatibleOs|originalPnpDisabledValue=$originalPnpDisabledValue|pnpVulnerableFeaturesDisabled=$pnpDisabled|mitigationApplied=$mitigationApplied|patchApplied=$patchApplied|protected=$protected"
     Return
 }
 
@@ -506,7 +506,7 @@ If (!$compatibleOs) {
     $protected = 1
 
     # Exit Point
-    Write-Output "outputLog=$output|compatibleOs=$compatibleOs|originalPnpDisabledValue=$originalPnpDisabledValue|pnpVulnerableFeaturesDisabled=$pnpDisabled|mitigationApplied=$mitigationApplied|patchApplied=$patchApplied|protected=$protected"
+    Write-Output "outputLog=$($output -join '`n')|compatibleOs=$compatibleOs|originalPnpDisabledValue=$originalPnpDisabledValue|pnpVulnerableFeaturesDisabled=$pnpDisabled|mitigationApplied=$mitigationApplied|patchApplied=$patchApplied|protected=$protected"
     Return
 }
 
@@ -529,7 +529,7 @@ If (!$patchApplied) {
     Remove-Mitigation
     $mitigationApplied = 0
 
-    $output += "Removed mitigation temporarily during installation."
+    $output += "outputLog=$($output -join ' `n')ation temporarily during installation."
     $output += Install-Patch -PatchKb $kb -PatchUrl $url
 
     # If the patch was sucessfully installed
@@ -596,5 +596,5 @@ If ($patchApplied) {
     $protected = 1
 }
 
-Write-Output "outputLog=$output|compatibleOs=$compatibleOs|originalPnpDisabledValue=$originalPnpDisabledValue|pnpVulnerableFeaturesDisabled=$pnpDisabled|mitigationApplied=$mitigationApplied|patchApplied=$patchApplied|protected=$protected|restrictDriverInstallation=$restrictDriverInstallation"
+Write-Output "outputLog=$($output -join '`n')|compatibleOs=$compatibleOs|originalPnpDisabledValue=$originalPnpDisabledValue|pnpVulnerableFeaturesDisabled=$pnpDisabled|mitigationApplied=$mitigationApplied|patchApplied=$patchApplied|protected=$protected|restrictDriverInstallation=$restrictDriverInstallation"
 Return

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -103,157 +103,179 @@ If ($osName -like 'Microsoft Windows Server 2008*' -and $osName -notlike '*R2*')
 
 Switch ($os) {
     '7_32-bit' {
-        $kb =       'KB5004951';
-        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004951-x86_09808f3b8a74ce862f6e21ba36617c5b9bd53a3d.msu'
-        $ssu =      'KB5004378'
-        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004378-x86_7f71df13245adc8c835fccdeba92303b08e26a10.msu'
+        $kb =           'KB5004951'
+        $cumulativeKb = 'KB5004951'
+        $ssu =          'KB5004378'
+        $cumulativeUrl ='http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004951-x86_09808f3b8a74ce862f6e21ba36617c5b9bd53a3d.msu'
+        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004378-x86_7f71df13245adc8c835fccdeba92303b08e26a10.msu'
     }
     '7_64-bit' {
-        $kb =       'KB5004951';
-        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.1-kb5004951-x64_2fcf9eaa66615884884cc1cb9f75fc96294cbf2a.msu'
-        $ssu =      'KB5004378'
-        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004378-x64_e295e0dfb732d1d4712c6aa5ac72aa28a7067359.msu'
+        $kb =           'KB5004951'
+        $ssu =          'KB5004378'
+        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.1-kb5004951-x64_2fcf9eaa66615884884cc1cb9f75fc96294cbf2a.msu'
+        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004378-x64_e295e0dfb732d1d4712c6aa5ac72aa28a7067359.msu'
     }
     '2008_32-bit' {
-        $kb =       'KB5004959';
-        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.0-kb5004959-x86_7d5c62a788b49b296de559b792a8e1cd5b3fad2d.msu'
-        $ssu =      'KB4580971'
-        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2020/10/windows6.0-kb4580971-x86_5a4cf976c650cf9b6a0800aaf6016726f4b08c7d.msu'
+        $kb =           'KB5004959'
+        $ssu =          'KB4580971'
+        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.0-kb5004959-x86_7d5c62a788b49b296de559b792a8e1cd5b3fad2d.msu'
+        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2020/10/windows6.0-kb4580971-x86_5a4cf976c650cf9b6a0800aaf6016726f4b08c7d.msu'
     }
     '2008_64-bit' {
-        $kb =       'KB5004959';
-        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.0-kb5004959-x64_7bfadd426a5764d3a2886afbb73f727fae5e0f67.msu'
-        $ssu =      'KB4580971'
-        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2020/10/windows6.0-kb4580971-x64_619424830431f3fba3c6d086b5dbe3e1ddf42f1f.msu'
+        $kb =           'KB5004959'
+        $ssu =          'KB4580971'
+        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.0-kb5004959-x64_7bfadd426a5764d3a2886afbb73f727fae5e0f67.msu'
+        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2020/10/windows6.0-kb4580971-x64_619424830431f3fba3c6d086b5dbe3e1ddf42f1f.msu'
     }
     '2008r2' {
-        $kb =       'KB5004951';
-        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.1-kb5004951-x64_2fcf9eaa66615884884cc1cb9f75fc96294cbf2a.msu'
-        $ssu =      'KB5004378'
-        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004378-x64_e295e0dfb732d1d4712c6aa5ac72aa28a7067359.msu'
+        $kb =           'KB5004951'
+        $ssu =          'KB5004378'
+        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.1-kb5004951-x64_2fcf9eaa66615884884cc1cb9f75fc96294cbf2a.msu'
+        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004378-x64_e295e0dfb732d1d4712c6aa5ac72aa28a7067359.msu'
     }
     '8.1_32-bit' {
-        $kb =       'KB5004958';
-        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x86_ee2308010d7605cad53e19a1bc762d85d044d88d.msu'
-        $ssu =      'KB5001403'
-        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8.1-kb5001403-x86_c59ac03777801436fa01dbf341f164a709ce8f8a.msu'
+        $kb =           'KB5004958'
+        $cumulativeKb = 'KB5004958'
+        $ssu =          'KB5001403'
+        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x86_ee2308010d7605cad53e19a1bc762d85d044d88d.msu'
+        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8.1-kb5001403-x86_c59ac03777801436fa01dbf341f164a709ce8f8a.msu'
     }
     '8.1_64-bit' {
-        $kb =       'KB5004958';
-        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x64_8b73440b9c53bcea2660d9409b6ad3920f104cd2.msu'
-        $ssu =      'KB5001403'
-        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8.1-kb5001403-x64_7f15c4b281f38d43475abb785a32dbaf0355bad5.msu'
+        $kb =           'KB5004958'
+        $cumulativeKb = 'KB5004958'
+        $ssu =          'KB5001403'
+        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x64_8b73440b9c53bcea2660d9409b6ad3920f104cd2.msu'
+        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8.1-kb5001403-x64_7f15c4b281f38d43475abb785a32dbaf0355bad5.msu'
     }
     '2012' {
-        $kb =       'KB5004960';
-        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows8-rt-kb5004960-x64_15b7362a1146198852b2be37c4997f81e16495b6.msu'
-        $ssu =      'KB5001401'
-        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8-rt-kb5001401-x64_1027ae2c9888c2dfe0caadeafc506b3012789c56.msu'
+        $kb =           'KB5004960'
+        $cumulativeKb = 'KB5004960'
+        $ssu =          'KB5001401'
+        $cumulativeUrl ='http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows8-rt-kb5004960-x64_15b7362a1146198852b2be37c4997f81e16495b6.msu'
+        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8-rt-kb5001401-x64_1027ae2c9888c2dfe0caadeafc506b3012789c56.msu'
     }
     '2012r2' {
-        $kb =       'KB5004958';
-        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x64_8b73440b9c53bcea2660d9409b6ad3920f104cd2.msu'
-        $ssu =      'KB5001403'
-        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8.1-kb5001403-x64_7f15c4b281f38d43475abb785a32dbaf0355bad5.msu'
+        $kb =           'KB5004958'
+        $cumulativeKb = 'KB5004958'
+        $ssu =          'KB5001403'
+        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x64_8b73440b9c53bcea2660d9409b6ad3920f104cd2.msu'
+        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8.1-kb5001403-x64_7f15c4b281f38d43475abb785a32dbaf0355bad5.msu'
     }
     '2016' {
-        $kb =       'KB5004238';
-        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004238-x64_e3dd1cf22b1146f2469ef31f5fec0f47c8b5960b.msu'
-        $ssu =      'KB5001402'
-        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001402-x64_0108fcc32c0594f8578c3787babb7d84e6363864.msu'
+        $kb =           'KB5004948'
+        $cumulativeKb = 'KB5004238'
+        $ssu =          'KB5001402'
+        $cumulativeUrl ='http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004238-x64_e3dd1cf22b1146f2469ef31f5fec0f47c8b5960b.msu'
+        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001402-x64_0108fcc32c0594f8578c3787babb7d84e6363864.msu'
     }
     '2019' {
-        $kb =       'KB5004244';
-        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004244-x64_5685623313a6de061e0c42fed3391c29750a6b1b.msu'
-        $ssu =      'KB5003711'
-        $ssuUrl =   'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/06/windows10.0-kb5003711-x64_577dc9cfe2e84d23b193aae2678b12e777fc7e55.msu'
+        $kb =           'KB5004947'
+        $cumulativeKb = 'KB5004244'
+        $ssu =          'KB5003711'
+        $cumulativeUrl ='http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004244-x64_5685623313a6de061e0c42fed3391c29750a6b1b.msu'
+        $ssuUrl =       'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/06/windows10.0-kb5003711-x64_577dc9cfe2e84d23b193aae2678b12e777fc7e55.msu'
     }
     # 1507-1809 KBs specify they're for Win10 LTSB, so they might be unlikely to install... Not sure how to check at the moment.. related to the ESU question..
     '1507_32-bit' {
-        $kb =       'KB5004249'
-        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004249-x86_3011a800a44f3a2bd0d2baedb7a2f21dfc71c10e.msu'
-        $ssu =      'KB5001399'
-        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001399-x64_d33c5bf98f9c323bdfd3d7103a5215cb874221a1.msu'
+        $kb =           'KB5004950'
+        $cumulativeKb = 'KB5004249'
+        $ssu =          'KB5001399'
+        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004249-x86_3011a800a44f3a2bd0d2baedb7a2f21dfc71c10e.msu'
+        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001399-x64_d33c5bf98f9c323bdfd3d7103a5215cb874221a1.msu'
     }
     '1507_64-bit' {
-        $kb =       'KB5004249'
-        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004249-x64_38d93e844d6342c49b9df47247e54e60a41e4bb9.msu'
-        $ssu =      'KB5001399'
-        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001399-x86_e3fe821338f8dcc5b9abc712ce940f34b6ce4f9e.msu'
+        $kb =           'KB5004950'
+        $cumulativeKb = 'KB5004249'
+        $ssu =          'KB5001399'
+        $cumulativeUrl ='http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004249-x64_38d93e844d6342c49b9df47247e54e60a41e4bb9.msu'
+        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001399-x86_e3fe821338f8dcc5b9abc712ce940f34b6ce4f9e.msu'
     }
     '1607_32-bit' {
-        $kb =       'KB5004238'
-        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004238-x86_8d000fa9d73ffb093affc1ab1f20270f6d5abdf2.msu'
-        $ssu =      'KB5001402'
-        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001402-x86_27a769112966bdc171f5f300bfd4819f02941f5a.msu'
+        $kb =           'KB5004948'
+        $cumulativeKb = 'KB5004238'
+        $ssu =          'KB5001402'
+        $cumulativeUrl ='http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004238-x86_8d000fa9d73ffb093affc1ab1f20270f6d5abdf2.msu'
+        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001402-x86_27a769112966bdc171f5f300bfd4819f02941f5a.msu'
     }
     '1607_64-bit' {
-        $kb =       'KB5004238'
-        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004238-x64_e3dd1cf22b1146f2469ef31f5fec0f47c8b5960b.msu'
-        $ssu =      'KB5001402'
-        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001402-x64_0108fcc32c0594f8578c3787babb7d84e6363864.msu'
+        $kb =           'KB5004948'
+        $cumulativeKb = 'KB5004238'
+        $ssu =          'KB5001402'
+        $cumulativeUrl ='http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004238-x64_e3dd1cf22b1146f2469ef31f5fec0f47c8b5960b.msu'
+        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001402-x64_0108fcc32c0594f8578c3787babb7d84e6363864.msu'
     }
     '1809_32-bit' {
-        $kb =       'KB5004244'
-        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004244-x86_f3b02d749e702248c4932721f5f58c2fc6378684.msu'
-        $ssu =      'KB5003711'
-        $ssuUrl =   'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/06/windows10.0-kb5003711-x86_70a7ef9f67506eaeac5ae1747e90220e04e22492.msu'
+        $kb =           'KB5004947'
+        $cumulativeKb = 'KB5004244'
+        $ssu =          'KB5003711'
+        $cumulativeUrl ='http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004244-x86_f3b02d749e702248c4932721f5f58c2fc6378684.msu'
+        $ssuUrl =       'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/06/windows10.0-kb5003711-x86_70a7ef9f67506eaeac5ae1747e90220e04e22492.msu'
     }
     '1809_64-bit' {
-        $kb =       'KB5004244'
-        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004244-x64_5685623313a6de061e0c42fed3391c29750a6b1b.msu'
-        $ssu =      'KB5003711'
-        $ssuUrl =   'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/06/windows10.0-kb5003711-x64_577dc9cfe2e84d23b193aae2678b12e777fc7e55.msu'
+        $kb =           'KB5004947'
+        $cumulativeKb = 'KB5004244'
+        $ssu =          'KB5003711'
+        $cumulativeUrl ='http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004244-x64_5685623313a6de061e0c42fed3391c29750a6b1b.msu'
+        $ssuUrl =       'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/06/windows10.0-kb5003711-x64_577dc9cfe2e84d23b193aae2678b12e777fc7e55.msu'
     }
     '1909_32-bit' {
-        $kb =       'KB5004245'
-        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004245-x86_1ff53f72381912f791e0a1a5fa3e2bbf41bdcf23.msu'
-        $ssu =      'KB5004748'
-        $ssuUrl =   'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004748-x86_e456b8de1221c6e9ecfd9083fd3dbe2034325559.msu'
+        $kb =           'KB5004946'
+        $cumulativeKb = 'KB5004245'
+        $ssu =          'KB5004748'
+        $cumulativeUrl ='http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004245-x86_1ff53f72381912f791e0a1a5fa3e2bbf41bdcf23.msu'
+        $ssuUrl =       'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004748-x86_e456b8de1221c6e9ecfd9083fd3dbe2034325559.msu'
     }
     '1909_64-bit' {
-        $kb =       'KB5004245'
-        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004245-x64_1a7054d81cab082980ad25de1395987b94a79893.msu'
-        $ssu =      'KB5004748'
-        $ssuUrl =   'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004748-x64_2327ee6b541a2665817cc211f2fb832cc98031ac.msu'
+        $kb =           'KB5004946'
+        $cumulativeKb = 'KB5004245'
+        $ssu =          'KB5004748'
+        $cumulativeUrl ='http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004245-x64_1a7054d81cab082980ad25de1395987b94a79893.msu'
+        $ssuUrl =       'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004748-x64_2327ee6b541a2665817cc211f2fb832cc98031ac.msu'
     }
     '2004_32-bit' {
-        $kb =       'KB5004237'
-        $ssu =      'KB4598481'
-        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x86_571a793bba0b7d881e7076f83b7f1245ff41011f.msu'
-        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x86_32286dd2d08021ce7ce35ee4855beb81c8d5f09e.msu'
+        $kb =           'KB5004945'
+        $cumulativeKb = 'KB5004237'
+        $ssu =          'KB4598481'
+        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x86_571a793bba0b7d881e7076f83b7f1245ff41011f.msu'
+        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x86_32286dd2d08021ce7ce35ee4855beb81c8d5f09e.msu'
     }
     '2004_64-bit' {
-        $kb =       'KB5004237'
-        $ssu =      'KB4598481'
-        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x64_9a7c569f5656d99533e9e945e8063251758ce4c0.msu'
-        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x64_749fe79fd2e31b145de37c2f9ebf4f711d174dc2.msu'
+        $kb =           'KB5004945'
+        $cumulativeKb = 'KB5004237'
+        $ssu =          'KB4598481'
+        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x64_9a7c569f5656d99533e9e945e8063251758ce4c0.msu'
+        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x64_749fe79fd2e31b145de37c2f9ebf4f711d174dc2.msu'
     }
     '20H2_32-bit' {
-        $kb =       'KB5004237'
-        $ssu =      'KB4598481'
-        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x86_571a793bba0b7d881e7076f83b7f1245ff41011f.msu'
-        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x86_32286dd2d08021ce7ce35ee4855beb81c8d5f09e.msu'
+        $kb =           'KB5004945'
+        $cumulativeKb = 'KB5004237'
+        $ssu =          'KB4598481'
+        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x86_571a793bba0b7d881e7076f83b7f1245ff41011f.msu'
+        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x86_32286dd2d08021ce7ce35ee4855beb81c8d5f09e.msu'
     }
     '20H2_64-bit' {
-        $kb =       'KB5004237'
-        $ssu =      'KB4598481'
-        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x64_9a7c569f5656d99533e9e945e8063251758ce4c0.msu'
-        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x64_749fe79fd2e31b145de37c2f9ebf4f711d174dc2.msu'
+        $kb =           'KB5004945'
+        $cumulativeKb = 'KB5004237'
+        $ssu =          'KB4598481'
+        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x64_9a7c569f5656d99533e9e945e8063251758ce4c0.msu'
+        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x64_749fe79fd2e31b145de37c2f9ebf4f711d174dc2.msu'
     }
     # 21H12 doesn't currently have an SSU
     '21H1_32-bit' {
-        $kb =       'KB5004237'
-        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x86_571a793bba0b7d881e7076f83b7f1245ff41011f.msu'
+        $kb =           'KB5004945'
+        $cumulativeKb = 'KB5004237'
+        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x86_571a793bba0b7d881e7076f83b7f1245ff41011f.msu'
     }
     '21H1_64-bit' {
-        $kb =       'KB5004237'
-        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x64_9a7c569f5656d99533e9e945e8063251758ce4c0.msu'
+        $kb =           'KB5004945'
+        $cumulativeKb = 'KB5004237'
+        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x64_9a7c569f5656d99533e9e945e8063251758ce4c0.msu'
     }
     Default   {
         $kb = $Null
-        $url = $Null
+        $cumulativeKb = $Null
         $ssu = $Null
+        $cumulativeUrl = $Null
         $ssuUrl = $Null
     }
 }
@@ -431,7 +453,7 @@ function Get-PnpFeaturesDisabled {
 <# ------------------------ Answer important questions ------------------------------------- #>
 
 # If OS has compatible patch
-If ($os -and $kb) {
+If ($os -and ($cumulativeKb -or $kb)) {
     $compatibleOs = 1
 }
 
@@ -440,8 +462,8 @@ If (Test-MitigationApplied) {
     $mitigationApplied = 1
 }
 
-# If it is a compatible OS and patch is installed
-If ($compatibleOs -and (Get-HotFix -Id $kb -EA 0)) {
+# If it is a compatible OS and an available hotfix OR cumulative is installed
+If ($compatibleOs -and ((Get-HotFix -Id $cumulativeKb -EA 0) -or (Get-HotFix -Id $kb -EA 0))) {
     $patchApplied = 1
 }
 
@@ -537,7 +559,7 @@ If (!$patchApplied) {
     $mitigationApplied = 0
 
     $output += "outputLog=$($output -join ' `n')ation temporarily during installation."
-    $output += Install-Patch -PatchKb $kb -PatchUrl $url
+    $output += Install-Patch -PatchKb $cumulativeKb -PatchUrl $cumulativeUrl
 
     # If the patch was sucessfully installed
     If ($output -like "*!SUCCESS*") {

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -95,32 +95,157 @@ If ($osName -like 'Microsoft Windows Server 2008*' -and $osName -notlike '*R2*')
 <# ------------------------ Determine which patch is applicable ------------------------------------- #>
 
 Switch ($os) {
-    '7_32-bit'      { $kb = 'KB5004951'; $url = 'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004951-x86_09808f3b8a74ce862f6e21ba36617c5b9bd53a3d.msu' }
-    '7_64-bit'      { $kb = 'KB5004951'; $url = 'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.1-kb5004951-x64_2fcf9eaa66615884884cc1cb9f75fc96294cbf2a.msu' }
-    '2008_32-bit'   { $kb = 'KB5004959'; $url = 'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.0-kb5004959-x86_7d5c62a788b49b296de559b792a8e1cd5b3fad2d.msu' }
-    '2008_64-bit'   { $kb = 'KB5004959'; $url = 'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.0-kb5004959-x64_7bfadd426a5764d3a2886afbb73f727fae5e0f67.msu' }
-    '2008r2'        { $kb = 'KB5004951'; $url = 'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.1-kb5004951-x64_2fcf9eaa66615884884cc1cb9f75fc96294cbf2a.msu' }
-    '8.1_32-bit'    { $kb = 'KB5004958'; $url = 'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x86_ee2308010d7605cad53e19a1bc762d85d044d88d.msu' }
-    '8.1_64-bit'    { $kb = 'KB5004954'; $url = 'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x64_8b73440b9c53bcea2660d9409b6ad3920f104cd2.msu' }
-    '2012'          { $kb = 'KB5004960'; $url = 'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows8-rt-kb5004960-x64_15b7362a1146198852b2be37c4997f81e16495b6.msu' }
-    '2012r2'        { $kb = 'KB5004958'; $url = 'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x64_8b73440b9c53bcea2660d9409b6ad3920f104cd2.msu' }
-    '2016'          { $kb = 'KB5004948'; $url = 'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004948-x64_206b586ca8f1947fdace0008ecd7c9ca77fd6876.msu' }
-    '2019'          { $kb = 'KB5004947'; $url = 'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004947-x64_c00ea7cdbfc6c5c637873b3e5305e56fafc4c074.msu' }
-    '1507_32-bit'   { $kb = 'KB5004950'; $url = 'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004950-x86_651a97e0e3240bdad318a460a4280a7db7b2ff4b.msu' }
-    '1507_64-bit'   { $kb = 'KB5004950'; $url = 'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004950-x64_0486d81a882c5665c84248517687a5088ef26bf1.msu' }
-    '1607_32-bit'   { $kb = 'KB5004948'; $url = 'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004948-x86_b8dd84f2def04dd3a1d7de42898f776359fb527b.msu' }
-    '1607_64-bit'   { $kb = 'KB5004948'; $url = 'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004948-x64_206b586ca8f1947fdace0008ecd7c9ca77fd6876.msu' }
-    '2004_32-bit'   { $kb = 'KB5004945'; $url = 'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004945-x86_c2550823b87bcdfd19ece438954db1cb45449590.msu' }
-    '2004_64-bit'   { $kb = 'KB5004945'; $url = 'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004945-x64_db8eafe34a43930a0d7c54d6464ff78dad605fb7.msu' }
-    '20H2_32-bit'   { $kb = 'KB5004945'; $url = 'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004945-x86_c2550823b87bcdfd19ece438954db1cb45449590.msu' }
-    '20H2_64-bit'   { $kb = 'KB5004945'; $url = 'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004945-x64_db8eafe34a43930a0d7c54d6464ff78dad605fb7.msu' }
-    '21H1_32-bit'   { $kb = 'KB5004945'; $url = 'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004945-x86_c2550823b87bcdfd19ece438954db1cb45449590.msu' }
-    '21H1_64-bit'   { $kb = 'KB5004945'; $url = 'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004945-x64_db8eafe34a43930a0d7c54d6464ff78dad605fb7.msu' }
-    '1909_32-bit'   { $kb = 'KB5004946'; $url = 'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004946-x86_61da9d07bc330ff34196f9724e3b2d26570883d0.msu' }
-    '1909_64-bit'   { $kb = 'KB5004946'; $url = 'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004946-x64_ae43950737d20f3368f17f9ab9db28eccdf8cf26.msu' }
-    '1809_32-bit'   { $kb = 'KB5004947'; $url = 'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004947-x86_2cd3b09c753c60d39cdc93bdec2d9f076cddf2e5.msu' }
-    '1809_64-bit'   { $kb = 'KB5004947'; $url = 'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004947-x64_c00ea7cdbfc6c5c637873b3e5305e56fafc4c074.msu' }
-    Default   { $kb = $Null; $url = $Null }
+    '7_32-bit' {
+        $kb =       'KB5004951';
+        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004951-x86_09808f3b8a74ce862f6e21ba36617c5b9bd53a3d.msu'
+        $ssu =      'KB5004378'
+        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004378-x86_7f71df13245adc8c835fccdeba92303b08e26a10.msu'
+    }
+    '7_64-bit' {
+        $kb =       'KB5004951';
+        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.1-kb5004951-x64_2fcf9eaa66615884884cc1cb9f75fc96294cbf2a.msu'
+        $ssu =      'KB5004378'
+        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004378-x64_e295e0dfb732d1d4712c6aa5ac72aa28a7067359.msu'
+    }
+    '2008_32-bit' {
+        $kb =       'KB5004959';
+        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.0-kb5004959-x86_7d5c62a788b49b296de559b792a8e1cd5b3fad2d.msu'
+        $ssu =      'KB4580971'
+        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2020/10/windows6.0-kb4580971-x86_5a4cf976c650cf9b6a0800aaf6016726f4b08c7d.msu'
+    }
+    '2008_64-bit' {
+        $kb =       'KB5004959';
+        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.0-kb5004959-x64_7bfadd426a5764d3a2886afbb73f727fae5e0f67.msu'
+        $ssu =      'KB4580971'
+        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2020/10/windows6.0-kb4580971-x64_619424830431f3fba3c6d086b5dbe3e1ddf42f1f.msu'
+    }
+    '2008r2' {
+        $kb =       'KB5004951';
+        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.1-kb5004951-x64_2fcf9eaa66615884884cc1cb9f75fc96294cbf2a.msu'
+        $ssu =      'KB5004378'
+        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004378-x64_e295e0dfb732d1d4712c6aa5ac72aa28a7067359.msu'
+    }
+    # Windows 8.1 doesn't have any SSU
+    '8.1_32-bit' {
+        $kb =       'KB5004958';
+        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x86_ee2308010d7605cad53e19a1bc762d85d044d88d.msu'
+    }
+    '8.1_64-bit' {
+        $kb =       'KB5004954';
+        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x64_8b73440b9c53bcea2660d9409b6ad3920f104cd2.msu'
+    }
+    '2012' {
+        $kb =       'KB5004960';
+        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows8-rt-kb5004960-x64_15b7362a1146198852b2be37c4997f81e16495b6.msu'
+        $ssu =      'KB5001401'
+        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8-rt-kb5001401-x64_1027ae2c9888c2dfe0caadeafc506b3012789c56.msu'
+    }
+    '2012r2' {
+        $kb =       'KB5004958';
+        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x64_8b73440b9c53bcea2660d9409b6ad3920f104cd2.msu'
+        $ssu =      'KB5001403'
+        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8.1-kb5001403-x64_7f15c4b281f38d43475abb785a32dbaf0355bad5.msu'
+    }
+    '2016' {
+        $kb =       'KB5004948';
+        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004948-x64_206b586ca8f1947fdace0008ecd7c9ca77fd6876.msu'
+        $ssu =      'KB5001402'
+        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001402-x64_0108fcc32c0594f8578c3787babb7d84e6363864.msu'
+    }
+    '2019' {
+        $kb =       'KB5004947';
+        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004947-x64_c00ea7cdbfc6c5c637873b3e5305e56fafc4c074.msu'
+        $ssu =      'KB5003711'
+        $ssuUrl =   'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/06/windows10.0-kb5003711-x64_577dc9cfe2e84d23b193aae2678b12e777fc7e55.msu'
+    }
+    # 1507-1809 KBs specify they're for Win10 LTSB, so they might be unlikely to install... Not sure how to check at the moment.. related to the ESU question..
+    '1507_32-bit' {
+        $kb =       'KB5004950'
+        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004950-x86_651a97e0e3240bdad318a460a4280a7db7b2ff4b.msu'
+        $ssu =      'KB5001399'
+        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001399-x64_d33c5bf98f9c323bdfd3d7103a5215cb874221a1.msu'
+    }
+    '1507_64-bit' {
+        $kb =       'KB5004950'
+        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004950-x64_0486d81a882c5665c84248517687a5088ef26bf1.msu'
+        $ssu =      'KB5001399'
+        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001399-x86_e3fe821338f8dcc5b9abc712ce940f34b6ce4f9e.msu'
+    }
+    '1607_32-bit' {
+        $kb =       'KB5004948'
+        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004948-x86_b8dd84f2def04dd3a1d7de42898f776359fb527b.msu'
+        $ssu =      'KB5001402'
+        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001402-x86_27a769112966bdc171f5f300bfd4819f02941f5a.msu'
+    }
+    '1607_64-bit' {
+        $kb =       'KB5004948'
+        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004948-x64_206b586ca8f1947fdace0008ecd7c9ca77fd6876.msu'
+        $ssu =      'KB5001402'
+        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001402-x64_0108fcc32c0594f8578c3787babb7d84e6363864.msu'
+    }
+    '1809_32-bit' {
+        $kb =       'KB5004947'
+        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004947-x86_2cd3b09c753c60d39cdc93bdec2d9f076cddf2e5.msu'
+        $ssu =      'KB5003711'
+        $ssuUrl =   'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/06/windows10.0-kb5003711-x86_70a7ef9f67506eaeac5ae1747e90220e04e22492.msu'
+    }
+    '1809_64-bit' {
+        $kb =       'KB5004947'
+        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004947-x64_c00ea7cdbfc6c5c637873b3e5305e56fafc4c074.msu'
+        $ssu =      'KB5003711'
+        $ssuUrl =   'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/06/windows10.0-kb5003711-x64_577dc9cfe2e84d23b193aae2678b12e777fc7e55.msu'
+    }
+    '1909_32-bit' {
+        $kb =       'KB5004946'
+        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004946-x86_61da9d07bc330ff34196f9724e3b2d26570883d0.msu'
+        $ssu =      'KB5004748'
+        $ssuUrl =   'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004748-x86_e456b8de1221c6e9ecfd9083fd3dbe2034325559.msu'
+    }
+    '1909_64-bit' {
+        $kb =       'KB5004946'
+        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004946-x64_ae43950737d20f3368f17f9ab9db28eccdf8cf26.msu'
+        $ssu =      'KB5004748'
+        $ssuUrl =   'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004748-x64_2327ee6b541a2665817cc211f2fb832cc98031ac.msu'
+    }
+    '2004_32-bit' {
+        $kb =       'KB5004945'
+        $ssu =      'KB4598481'
+        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004945-x86_c2550823b87bcdfd19ece438954db1cb45449590.msu'
+        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x86_32286dd2d08021ce7ce35ee4855beb81c8d5f09e.msu'
+    }
+    '2004_64-bit' {
+        $kb =       'KB5004945'
+        $ssu =      'KB4598481'
+        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004945-x64_db8eafe34a43930a0d7c54d6464ff78dad605fb7.msu'
+        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x64_749fe79fd2e31b145de37c2f9ebf4f711d174dc2.msu'
+    }
+    '20H2_32-bit' {
+        $kb =       'KB5004945'
+        $ssu =      'KB4598481'
+        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004945-x86_c2550823b87bcdfd19ece438954db1cb45449590.msu'
+        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x86_32286dd2d08021ce7ce35ee4855beb81c8d5f09e.msu'
+    }
+    '20H2_64-bit' {
+        $kb =       'KB5004945'
+        $ssu =      'KB4598481'
+        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004945-x64_db8eafe34a43930a0d7c54d6464ff78dad605fb7.msu'
+        $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x64_749fe79fd2e31b145de37c2f9ebf4f711d174dc2.msu'
+    }
+    # 21H12 doesn't currently have an SSU
+    '21H1_32-bit' {
+        $kb =       'KB5004945'
+        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004945-x86_c2550823b87bcdfd19ece438954db1cb45449590.msu'
+    }
+    '21H1_64-bit' {
+        $kb =       'KB5004945'
+        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004945-x64_db8eafe34a43930a0d7c54d6464ff78dad605fb7.msu'
+    }
+    Default   {
+        $kb = $Null
+        $url = $Null
+        $ssu = $Null
+        $ssuUrl = $Null
+    }
 }
 
 <# ------------------------ Mitigation helper functions ------------------------------------- #>

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -42,6 +42,13 @@ $restrictDriverInstallation = 0
 # Will hold saved pnp reg settings state if exists
 $originalPnpDisabledValue = ''
 
+# possibly for future use.. can't find win10 example or way to test validity of approach
+# $ESUWin7Year1 = (Get-WmiObject softwarelicensingproduct -filter "ID='77db037b-95c3-48d7-a3ab-a9c6d41093e0'" | Select LicenseStatus)
+# $ESUWin7Year2 = (Get-WmiObject softwarelicensingproduct -filter "ID='0e00c25d-8795-4fb7-9572-3803d91b6880'" | Select LicenseStatus)
+# $ESUWin7Year3 = (Get-WmiObject softwarelicensingproduct -filter "ID='4220f546-f522-46df-8202-4d07afd26454'" | Select LicenseStatus)
+# $ESUWin2008Year1 = (Get-WmiObject softwarelicensingproduct -filter "ID='553673ed-6ddf-419c-a153-b760283472fd'" | Select LicenseStatus)
+# $ESUWin2008Year2 = (Get-WmiObject softwarelicensingproduct -filter "ID='04fa0286-fa74-401e-bbe9-fbfbb158010d'" | Select LicenseStatus)
+# $ESUWin2008Year3 = (Get-WmiObject softwarelicensingproduct -filter "ID='16c08c85-0c8b-4009-9b2b-f1f7319e45f9'" | Select LicenseStatus)
 
 <# ------------------------ Gather info from environment ------------------------------------- #>
 

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -328,6 +328,7 @@ function Install-Patch (
     $PatchUrl
 ) {
     [array]$out
+    $patchPath = "$patchDir\$PatchKb.msu"
 
     If (!(Test-Path -Path $patchDir -PathType Container)) {
         New-Item $patchDir -ItemType Directory | Out-Null
@@ -344,29 +345,29 @@ function Install-Patch (
 
     Try {
         [Net.ServicePointManager]::SecurityProtocol = [Enum]::ToObject([Net.SecurityProtocolType], 3072)
-        (New-Object System.Net.WebClient).DownloadFile($PatchUrl,"$patchDir\$PatchKb.msu")
+        (New-Object System.Net.WebClient).DownloadFile($PatchUrl, $patchPath)
     } Catch {
         # Couldn't download. Exit early.
         $out += "There was an error downloading the patch from $PatchUrl -> $Error"
         Return $out -join "`n"
     }
 
+    # TODO: Check hash here before proceeding...........
+
     Try {
         $out += "Installing $($PatchKb)..."
-        Start-Process -FilePath wusa.exe -ArgumentList """$patchDir\$PatchKb.msu"" /quiet /norestart /log:""$patchDir\$($PatchKb)-InstallLog.evt""" -Wait
+        Start-Process -FilePath wusa.exe -ArgumentList """$patchPath"" /quiet /norestart /log:""$patchDir\$($PatchKb)-InstallLog.evt""" -Wait
     } Catch {
         # Installation failed.
         $out += "Installation failed."
     }
 
-    # Clean up downloaded patch
-    # TODO: only delete file after successful installation to avoid re-downloading. Would need to hash check.
-    Remove-Item -Path "$patchDir\$PatchKb.msu" -Force
-
     If (Get-HotFix -Id $PatchKb -EA 0) {
-        $out += "!SUCCESS: $PatchKb was successfully installed."
+        # Clean up downloaded patch
+        Remove-Item -Path $patchPath -Force
+        $out += "!SUCCESS: $PatchKb was successfully installed. Removed downloaded file."
     } Else {
-        $out += "!FAILED: $PatchKb installation failed."
+        $out += "!FAILED: $PatchKb installation failed. Leaving downloaded file in place for future installation attempts."
     }
 
     Return $out -join "`n"

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -42,6 +42,9 @@ $restrictDriverInstallation = 0
 # Will hold saved pnp reg settings state if exists
 $originalPnpDisabledValue = ''
 
+# If previous installation detected
+$previousInstallationAttempted = 0
+
 # possibly for future use.. can't find win10 example or way to test validity of approach
 # $ESUWin7Year1 = (Get-WmiObject softwarelicensingproduct -filter "ID='77db037b-95c3-48d7-a3ab-a9c6d41093e0'" | Select LicenseStatus)
 # $ESUWin7Year2 = (Get-WmiObject softwarelicensingproduct -filter "ID='0e00c25d-8795-4fb7-9572-3803d91b6880'" | Select LicenseStatus)
@@ -473,19 +476,22 @@ $pnpDisabled = Get-PnpFeaturesDisabled
 # If RestrictDriverInstallationToAdministrators is true
 $restrictDriverInstallation = (Get-ItemProperty -Path $PnpRegPath -Name "RestrictDriverInstallationToAdministrators" -EA 0).RestrictDriverInstallationToAdministrators
 
+# Previous installation attempted?
+$previousInstallAttemptPath = "$ltPath\security\printnightmare\$os-$cumulativeKb.txt"
+
 # If pnp reg settings exist and are enabled, in case an issue is caused and we need to know if pnp reg settings
 # were originally enabled, save initial state
-$path = "$ltPath\security\printnightmare\pnpState.txt"
+$pnpStatePath = "$ltPath\security\printnightmare\pnpState.txt"
 
 # If no file, no previous state is saved
-If (!(Test-Path -Path $path)) {
+If (!(Test-Path -Path $pnpStatePath)) {
     # if vulnerable pnp features are currently enabled
     If (!$pnpDisabled) {
         # Save current values to file
         $pnp1Enabled = (Get-ItemProperty -Path $PnpRegPath -Name "NoWarningNoElevationOnInstall" -EA 0).NoWarningNoElevationOnInstall
         $pnp2Enabled = (Get-ItemProperty -Path $PnpRegPath -Name "UpdatePromptSettings" -EA 0).UpdatePromptSettings
 
-        New-Item $path -ItemType File -Force -Value "NoWarningNoElevationOnInstall=$pnp1Enabled,UpdatePromptSettings=$pnp2Enabled" | Out-Null
+        New-Item $pnpStatePath -ItemType File -Force -Value "NoWarningNoElevationOnInstall=$pnp1Enabled,UpdatePromptSettings=$pnp2Enabled" | Out-Null
         $originalPnpDisabledValue = 0
     } Else {
         # The file doesn't exist, and pnp features are disabled, so don't save the state. No file means they were never enabled.
@@ -521,6 +527,29 @@ If ($excludeFromMitigation -eq 1) {
     }
 
     # Exit Point
+    Write-Output "outputLog=$($output -join '`n')|compatibleOs=$compatibleOs|originalPnpDisabledValue=$originalPnpDisabledValue|pnpVulnerableFeaturesDisabled=$pnpDisabled|mitigationApplied=$mitigationApplied|patchApplied=$patchApplied|protected=$protected"
+    Return
+}
+
+If ((!$patchApplied -and $compatibleOs) -and (Test-Path -Path $previousInstallAttemptPath)) {
+    # This has tried to install before at apparently did not succeed
+    $output += "This installation was attempted in the past and failed. Not trying again."
+
+    # Reapply mitigation
+    $output += Apply-Mitigation
+
+    If (Test-MitigationApplied) {
+        $output += "ACL mitigation reapplied successfully."
+        $protected = 1
+        $mitigationApplied = 1
+        $compatibleOs = 0
+    } Else {
+        $output += "Applying the ACL mitigation did not work for some reason."
+        $protected = 0
+        $mitigationApplied = 0
+        $compatibleOs = 0
+    }
+
     Write-Output "outputLog=$($output -join '`n')|compatibleOs=$compatibleOs|originalPnpDisabledValue=$originalPnpDisabledValue|pnpVulnerableFeaturesDisabled=$pnpDisabled|mitigationApplied=$mitigationApplied|patchApplied=$patchApplied|protected=$protected"
     Return
 }
@@ -564,6 +593,7 @@ If (!$patchApplied) {
     # If the patch was sucessfully installed
     If ($output -like "*!SUCCESS*") {
         $patchApplied = 1
+        New-Item $previousInstallAttemptPath -ItemType File -Force | Out-Null
     } Else {
         $patchApplied = 0
     }
@@ -573,6 +603,12 @@ If (!$patchApplied) {
 
 If ($patchApplied) {
     # Patch is installed
+
+    # If file marking successful installation doesn't exist, create it
+    If (!(Test-Path -Path $previousInstallAttemptPath)) {
+        New-Item $previousInstallAttemptPath -ItemType File -Force | Out-Null
+    }
+
     If ($restrictDriverInstallation -eq 1) {
         # and driver installation restricted to admins, so protected
         $output += "Patch is installed and driver installation is restricted to administrators. Not Vulnerable!"

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -147,98 +147,98 @@ Switch ($os) {
         $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8.1-kb5001403-x64_7f15c4b281f38d43475abb785a32dbaf0355bad5.msu'
     }
     '2016' {
-        $kb =       'KB5004948';
-        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004948-x64_206b586ca8f1947fdace0008ecd7c9ca77fd6876.msu'
+        $kb =       'KB5004238';
+        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004238-x64_e3dd1cf22b1146f2469ef31f5fec0f47c8b5960b.msu'
         $ssu =      'KB5001402'
         $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001402-x64_0108fcc32c0594f8578c3787babb7d84e6363864.msu'
     }
     '2019' {
-        $kb =       'KB5004947';
-        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004947-x64_c00ea7cdbfc6c5c637873b3e5305e56fafc4c074.msu'
+        $kb =       'KB5004244';
+        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004244-x64_5685623313a6de061e0c42fed3391c29750a6b1b.msu'
         $ssu =      'KB5003711'
         $ssuUrl =   'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/06/windows10.0-kb5003711-x64_577dc9cfe2e84d23b193aae2678b12e777fc7e55.msu'
     }
     # 1507-1809 KBs specify they're for Win10 LTSB, so they might be unlikely to install... Not sure how to check at the moment.. related to the ESU question..
     '1507_32-bit' {
-        $kb =       'KB5004950'
-        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004950-x86_651a97e0e3240bdad318a460a4280a7db7b2ff4b.msu'
+        $kb =       'KB5004249'
+        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004249-x86_3011a800a44f3a2bd0d2baedb7a2f21dfc71c10e.msu'
         $ssu =      'KB5001399'
         $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001399-x64_d33c5bf98f9c323bdfd3d7103a5215cb874221a1.msu'
     }
     '1507_64-bit' {
-        $kb =       'KB5004950'
-        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004950-x64_0486d81a882c5665c84248517687a5088ef26bf1.msu'
+        $kb =       'KB5004249'
+        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004249-x64_38d93e844d6342c49b9df47247e54e60a41e4bb9.msu'
         $ssu =      'KB5001399'
         $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001399-x86_e3fe821338f8dcc5b9abc712ce940f34b6ce4f9e.msu'
     }
     '1607_32-bit' {
-        $kb =       'KB5004948'
-        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004948-x86_b8dd84f2def04dd3a1d7de42898f776359fb527b.msu'
+        $kb =       'KB5004238'
+        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004238-x86_8d000fa9d73ffb093affc1ab1f20270f6d5abdf2.msu'
         $ssu =      'KB5001402'
         $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001402-x86_27a769112966bdc171f5f300bfd4819f02941f5a.msu'
     }
     '1607_64-bit' {
-        $kb =       'KB5004948'
-        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004948-x64_206b586ca8f1947fdace0008ecd7c9ca77fd6876.msu'
+        $kb =       'KB5004238'
+        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004238-x64_e3dd1cf22b1146f2469ef31f5fec0f47c8b5960b.msu'
         $ssu =      'KB5001402'
         $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001402-x64_0108fcc32c0594f8578c3787babb7d84e6363864.msu'
     }
     '1809_32-bit' {
-        $kb =       'KB5004947'
-        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004947-x86_2cd3b09c753c60d39cdc93bdec2d9f076cddf2e5.msu'
+        $kb =       'KB5004244'
+        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004244-x86_f3b02d749e702248c4932721f5f58c2fc6378684.msu'
         $ssu =      'KB5003711'
         $ssuUrl =   'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/06/windows10.0-kb5003711-x86_70a7ef9f67506eaeac5ae1747e90220e04e22492.msu'
     }
     '1809_64-bit' {
-        $kb =       'KB5004947'
-        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004947-x64_c00ea7cdbfc6c5c637873b3e5305e56fafc4c074.msu'
+        $kb =       'KB5004244'
+        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004244-x64_5685623313a6de061e0c42fed3391c29750a6b1b.msu'
         $ssu =      'KB5003711'
         $ssuUrl =   'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/06/windows10.0-kb5003711-x64_577dc9cfe2e84d23b193aae2678b12e777fc7e55.msu'
     }
     '1909_32-bit' {
-        $kb =       'KB5004946'
-        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004946-x86_61da9d07bc330ff34196f9724e3b2d26570883d0.msu'
+        $kb =       'KB5004245'
+        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004245-x86_1ff53f72381912f791e0a1a5fa3e2bbf41bdcf23.msu'
         $ssu =      'KB5004748'
         $ssuUrl =   'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004748-x86_e456b8de1221c6e9ecfd9083fd3dbe2034325559.msu'
     }
     '1909_64-bit' {
-        $kb =       'KB5004946'
-        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004946-x64_ae43950737d20f3368f17f9ab9db28eccdf8cf26.msu'
+        $kb =       'KB5004245'
+        $url =      'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004245-x64_1a7054d81cab082980ad25de1395987b94a79893.msu'
         $ssu =      'KB5004748'
         $ssuUrl =   'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004748-x64_2327ee6b541a2665817cc211f2fb832cc98031ac.msu'
     }
     '2004_32-bit' {
-        $kb =       'KB5004945'
+        $kb =       'KB5004237'
         $ssu =      'KB4598481'
-        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004945-x86_c2550823b87bcdfd19ece438954db1cb45449590.msu'
+        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x86_571a793bba0b7d881e7076f83b7f1245ff41011f.msu'
         $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x86_32286dd2d08021ce7ce35ee4855beb81c8d5f09e.msu'
     }
     '2004_64-bit' {
-        $kb =       'KB5004945'
+        $kb =       'KB5004237'
         $ssu =      'KB4598481'
-        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004945-x64_db8eafe34a43930a0d7c54d6464ff78dad605fb7.msu'
+        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x64_9a7c569f5656d99533e9e945e8063251758ce4c0.msu'
         $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x64_749fe79fd2e31b145de37c2f9ebf4f711d174dc2.msu'
     }
     '20H2_32-bit' {
-        $kb =       'KB5004945'
+        $kb =       'KB5004237'
         $ssu =      'KB4598481'
-        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004945-x86_c2550823b87bcdfd19ece438954db1cb45449590.msu'
+        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x86_571a793bba0b7d881e7076f83b7f1245ff41011f.msu'
         $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x86_32286dd2d08021ce7ce35ee4855beb81c8d5f09e.msu'
     }
     '20H2_64-bit' {
-        $kb =       'KB5004945'
+        $kb =       'KB5004237'
         $ssu =      'KB4598481'
-        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004945-x64_db8eafe34a43930a0d7c54d6464ff78dad605fb7.msu'
+        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x64_9a7c569f5656d99533e9e945e8063251758ce4c0.msu'
         $ssuUrl =   'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x64_749fe79fd2e31b145de37c2f9ebf4f711d174dc2.msu'
     }
     # 21H12 doesn't currently have an SSU
     '21H1_32-bit' {
-        $kb =       'KB5004945'
-        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004945-x86_c2550823b87bcdfd19ece438954db1cb45449590.msu'
+        $kb =       'KB5004237'
+        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x86_571a793bba0b7d881e7076f83b7f1245ff41011f.msu'
     }
     '21H1_64-bit' {
-        $kb =       'KB5004945'
-        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004945-x64_db8eafe34a43930a0d7c54d6464ff78dad605fb7.msu'
+        $kb =       'KB5004237'
+        $url =      'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x64_9a7c569f5656d99533e9e945e8063251758ce4c0.msu'
     }
     Default   {
         $kb = $Null

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -321,7 +321,7 @@ function Apply-Mitigation {
 function Install-Patch (
     # the KB number of the patch you'd like to install
     [string]
-    $PatchKb
+    $PatchKb,
 
     # the URL to download the patch you'd like to install
     [string]


### PR DESCRIPTION
- Add all most recent SSU KBs/URLs and install if not already installed before attempting patch
- Replace all hotfix KBs/URLs with new Cumulatives (leave previous KBs in place to check for installation, no need to install cumulative if installed).
- Added hash checks to download/install process. Installation will only occur after file download completes and hash matches. Additionally, if download succeeds and hash matches, but installation fails, download will be kept for future attempts
- Create file upon successful installation (or upon already installed). Check for that file and don't reinstall if exists. This is to stop repeated failures.

Hash checks summary:
- if file exists already hash check and reuse
- if it does not, download and then hash check
- remove file only if installation succeeds