### PR TITLE
Fix some oses have no cumulative

### DIFF
--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -138,7 +138,7 @@ Switch ($os) {
     '8.1_32-bit' {
         $kb =           'KB5004958'
         $ssu =          'KB5001403'
-        $url ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x86_ee2308010d7605cad53e19a1bc762d85d044d88d.msu'
+        $url =          'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x86_ee2308010d7605cad53e19a1bc762d85d044d88d.msu'
         $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8.1-kb5001403-x86_c59ac03777801436fa01dbf341f164a709ce8f8a.msu'
     }
     '8.1_64-bit' {
@@ -155,9 +155,8 @@ Switch ($os) {
     }
     '2012r2' {
         $kb =           'KB5004958'
-        $cumulativeKb = 'KB5004958'
         $ssu =          'KB5001403'
-        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x64_8b73440b9c53bcea2660d9409b6ad3920f104cd2.msu'
+        $url =          'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x64_8b73440b9c53bcea2660d9409b6ad3920f104cd2.msu'
         $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8.1-kb5001403-x64_7f15c4b281f38d43475abb785a32dbaf0355bad5.msu'
     }
     '2016' {
@@ -473,7 +472,13 @@ $pnpDisabled = Get-PnpFeaturesDisabled
 $restrictDriverInstallation = (Get-ItemProperty -Path $PnpRegPath -Name "RestrictDriverInstallationToAdministrators" -EA 0).RestrictDriverInstallationToAdministrators
 
 # Previous installation attempted?
-$previousInstallAttemptPath = "$ltPath\security\printnightmare\$os-$cumulativeKb.txt"
+# Also need to check for previous versions of file... don't want to install if they exist either.
+$previousInstallAttemptPathOs = "$ltPath\security\printnightmare\$os.txt"
+If ($cumulativeKb) {
+    $previousInstallAttemptPathWithKb = "$ltPath\security\printnightmare\$os-$cumulativeKb.txt"
+} Else {
+    $previousInstallAttemptPathWithKb = "$ltPath\security\printnightmare\$os-$kb.txt"
+}
 
 # If pnp reg settings exist and are enabled, in case an issue is caused and we need to know if pnp reg settings
 # were originally enabled, save initial state
@@ -527,7 +532,10 @@ If ($excludeFromMitigation -eq 1) {
     Return
 }
 
-If ((!$patchApplied -and $compatibleOs) -and (Test-Path -Path $previousInstallAttemptPath)) {
+$previousInstallAttempted = (Test-Path -Path $previousInstallAttemptPathOs) -or (Test-Path -Path $previousInstallAttemptPathWithKb)
+
+# If patch is not applied, the OS is compatible, but this has been tried before...
+If ((!$patchApplied -and $compatibleOs) -and $previousInstallAttempted) {
     # This has tried to install before at apparently did not succeed
     $output += "This installation was attempted in the past and failed. Not trying again."
 
@@ -604,7 +612,7 @@ If (!$patchApplied) {
     # If the patch was sucessfully installed
     If ($output -like "*!SUCCESS*") {
         $patchApplied = 1
-        New-Item $previousInstallAttemptPath -ItemType File -Force | Out-Null
+        New-Item $previousInstallAttemptPathOs -ItemType File -Force | Out-Null
     } Else {
         $patchApplied = 0
     }
@@ -616,8 +624,8 @@ If ($patchApplied) {
     # Patch is installed
 
     # If file marking successful installation doesn't exist, create it
-    If (!(Test-Path -Path $previousInstallAttemptPath)) {
-        New-Item $previousInstallAttemptPath -ItemType File -Force | Out-Null
+    If (!(Test-Path -Path $previousInstallAttemptPathOs)) {
+        New-Item $previousInstallAttemptPathOs -ItemType File -Force | Out-Null
     }
 
     If ($restrictDriverInstallation -eq 1) {

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -532,7 +532,8 @@ If ($excludeFromMitigation -eq 1) {
     Return
 }
 
-$previousInstallAttempted = (Test-Path -Path $previousInstallAttemptPathOs) -or (Test-Path -Path $previousInstallAttemptPathWithKb)
+# $Null option included because some PCs in a previous version of the script did not have $kb set and could have resulted in that file name
+$previousInstallAttempted = (Test-Path -Path $previousInstallAttemptPathOs) -or (Test-Path -Path $previousInstallAttemptPathWithKb) -or (Test-Path -Path "$ltPath\security\printnightmare\$os-$Null.txt")
 
 # If patch is not applied, the OS is compatible, but this has been tried before...
 If ((!$patchApplied -and $compatibleOs) -and $previousInstallAttempted) {

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -42,8 +42,8 @@ $restrictDriverInstallation = 0
 # Will hold saved pnp reg settings state if exists
 $originalPnpDisabledValue = ''
 
-# If previous installation detected
-$previousInstallationAttempted = 0
+$applicableUrl = ''
+$applicableKb = ''
 
 # possibly for future use.. can't find win10 example or way to test validity of approach
 # $ESUWin7Year1 = (Get-WmiObject softwarelicensingproduct -filter "ID='77db037b-95c3-48d7-a3ab-a9c6d41093e0'" | Select LicenseStatus)
@@ -107,54 +107,50 @@ If ($osName -like 'Microsoft Windows Server 2008*' -and $osName -notlike '*R2*')
 Switch ($os) {
     '7_32-bit' {
         $kb =           'KB5004951'
-        $cumulativeKb = 'KB5004951'
         $ssu =          'KB5004378'
-        $cumulativeUrl ='http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004951-x86_09808f3b8a74ce862f6e21ba36617c5b9bd53a3d.msu'
+        $url =          'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004951-x86_09808f3b8a74ce862f6e21ba36617c5b9bd53a3d.msu'
         $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004378-x86_7f71df13245adc8c835fccdeba92303b08e26a10.msu'
     }
     '7_64-bit' {
         $kb =           'KB5004951'
         $ssu =          'KB5004378'
-        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.1-kb5004951-x64_2fcf9eaa66615884884cc1cb9f75fc96294cbf2a.msu'
+        $url =          'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.1-kb5004951-x64_2fcf9eaa66615884884cc1cb9f75fc96294cbf2a.msu'
         $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004378-x64_e295e0dfb732d1d4712c6aa5ac72aa28a7067359.msu'
     }
     '2008_32-bit' {
         $kb =           'KB5004959'
         $ssu =          'KB4580971'
-        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.0-kb5004959-x86_7d5c62a788b49b296de559b792a8e1cd5b3fad2d.msu'
+        $url =          'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.0-kb5004959-x86_7d5c62a788b49b296de559b792a8e1cd5b3fad2d.msu'
         $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2020/10/windows6.0-kb4580971-x86_5a4cf976c650cf9b6a0800aaf6016726f4b08c7d.msu'
     }
     '2008_64-bit' {
         $kb =           'KB5004959'
         $ssu =          'KB4580971'
-        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.0-kb5004959-x64_7bfadd426a5764d3a2886afbb73f727fae5e0f67.msu'
+        $url =          'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.0-kb5004959-x64_7bfadd426a5764d3a2886afbb73f727fae5e0f67.msu'
         $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2020/10/windows6.0-kb4580971-x64_619424830431f3fba3c6d086b5dbe3e1ddf42f1f.msu'
     }
     '2008r2' {
         $kb =           'KB5004951'
         $ssu =          'KB5004378'
-        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.1-kb5004951-x64_2fcf9eaa66615884884cc1cb9f75fc96294cbf2a.msu'
+        $url =          'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.1-kb5004951-x64_2fcf9eaa66615884884cc1cb9f75fc96294cbf2a.msu'
         $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004378-x64_e295e0dfb732d1d4712c6aa5ac72aa28a7067359.msu'
     }
     '8.1_32-bit' {
         $kb =           'KB5004958'
-        $cumulativeKb = 'KB5004958'
         $ssu =          'KB5001403'
-        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x86_ee2308010d7605cad53e19a1bc762d85d044d88d.msu'
+        $url ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x86_ee2308010d7605cad53e19a1bc762d85d044d88d.msu'
         $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8.1-kb5001403-x86_c59ac03777801436fa01dbf341f164a709ce8f8a.msu'
     }
     '8.1_64-bit' {
         $kb =           'KB5004958'
-        $cumulativeKb = 'KB5004958'
         $ssu =          'KB5001403'
-        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x64_8b73440b9c53bcea2660d9409b6ad3920f104cd2.msu'
+        $url =          'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x64_8b73440b9c53bcea2660d9409b6ad3920f104cd2.msu'
         $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8.1-kb5001403-x64_7f15c4b281f38d43475abb785a32dbaf0355bad5.msu'
     }
     '2012' {
         $kb =           'KB5004960'
-        $cumulativeKb = 'KB5004960'
         $ssu =          'KB5001401'
-        $cumulativeUrl ='http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows8-rt-kb5004960-x64_15b7362a1146198852b2be37c4997f81e16495b6.msu'
+        $url =          'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows8-rt-kb5004960-x64_15b7362a1146198852b2be37c4997f81e16495b6.msu'
         $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8-rt-kb5001401-x64_1027ae2c9888c2dfe0caadeafc506b3012789c56.msu'
     }
     '2012r2' {
@@ -588,7 +584,22 @@ If (!$patchApplied) {
     $mitigationApplied = 0
 
     $output += "Removed mitigation temporarily during installation."
-    $output += Install-Patch -PatchKb $cumulativeKb -PatchUrl $cumulativeUrl
+
+    # Download cumulative if available, otherwise download hotfix
+    If ($cumulativeUrl) {
+        $applicableUrl = $cumulativeUrl
+    } Else {
+        $applicableUrl = $url
+    }
+
+    # Install cumulative if available, otherwise install hotfix
+    If ($cumulativeKb) {
+        $applicableKb = $cumulativeKb
+    } Else {
+        $applicableKb = $
+    }
+
+    $output += Install-Patch -PatchKb $applicableKb -PatchUrl $applicableUrl
 
     # If the patch was sucessfully installed
     If ($output -like "*!SUCCESS*") {


### PR DESCRIPTION
The approach I previously took for OSes that didn't get a cumulative was not compatible with the way I was checking for previous install attempts.

For some OSes (win7, win8.1, 2008, 2012 and 2012r2), there was no kb/url set because some use cumulative and some don't, script wasn't considering that. Now, if cumulative exists, `$cumulativeKb` will be used, and if not, `$kb` will be used instead. Also `$cumulativeUrl` vs `$url` respectively.

Don't want the kb in the file name of the `previousInstallAttemptPath`, because we don't want a cumulative to install either in the case of an unsupported OS. Just check windows version. If win version were to change, it can try again. 

Also:
- Fixed one more no-cumulative case.
- Removed unused variable `$previousInstallationAttempted`
