### PR TITLE
Fixed issue with `get-hotfix`

### DIFF
--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -453,16 +453,20 @@ function Get-PnpFeaturesDisabled {
 # If OS has compatible patch
 If ($os -and ($cumulativeKb -or $kb)) {
     $compatibleOs = 1
+
+    # ..and an available hotfix OR cumulative is installed
+    If ($cumulativeKb -and (Get-Hotfix -Id $cumulativeKb)) {
+        $patchApplied = 1
+    }
+
+    If ($kb -and (Get-HotFix -Id $kb)) {
+        $patchApplied = 1
+    }
 }
 
 # If ACL mitigation is currently applied
 If (Test-MitigationApplied) {
     $mitigationApplied = 1
-}
-
-# If it is a compatible OS and an available hotfix OR cumulative is installed
-If ($compatibleOs -and ((Get-HotFix -Id $cumulativeKb -EA 0) -or (Get-HotFix -Id $kb -EA 0))) {
-    $patchApplied = 1
 }
 
 # If bad Point and Print settings are disabled according to registry

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -455,11 +455,11 @@ If ($os -and ($cumulativeKb -or $kb)) {
     $compatibleOs = 1
 
     # ..and an available hotfix OR cumulative is installed
-    If ($cumulativeKb -and (Get-Hotfix -Id $cumulativeKb)) {
+    If ($cumulativeKb -and (Get-Hotfix -Id $cumulativeKb -EA 0)) {
         $patchApplied = 1
     }
 
-    If ($kb -and (Get-HotFix -Id $kb)) {
+    If ($kb -and (Get-HotFix -Id $kb -EA 0)) {
         $patchApplied = 1
     }
 }


### PR DESCRIPTION
So, turns out `-EA 0`/`-ErrorAction SilentlyContinue` don't actually work for `Get-Hotfix`, it just errors anyway and stops execution of that line, so you can't do like `If ((Get-Hotfix -Id $Null -EA 0) -or $someTrueValue)` because `Get-HotFix` errors and you never make it to the 2nd part after the `-or`

This was causing a problem with `$patchApplied`  staying `0` on OSes where no cumulative was released, even when the hotfix was installed.