### PR TITLE
Printnightmare add superseding updates

### DIFF
--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -114,24 +114,32 @@ $8PatchKbs = @(
     'KB5004958'
 )
 
+$1507PatchKbs = @(
+    'KB5004950',
+    'KB5004249',
+    'KB5005040'
+)
+
 $1607PatchKbs = @(
     'KB5004948',
-    'KB5004238'
+    'KB5004238',
+    'KB5005393',
+    'KB5005043'
 )
 
 $1809PatchKbs = @(
     'KB5004947',
-    'KB5004244'
+    'KB5004244',
+    'KB5005394',
+    'KB5004308',
+    'KB5005030'
 )
 
 $1909PatchKbs = @(
     'KB5004946',
-    'KB5004245'
-)
-
-$1507PatchKbs = @(
-    'KB5004950',
-    'KB5004249'
+    'KB5004245',
+    'KB5004293',
+    'KB5005031'
 )
 
 $2004AndNewerSsuKb = 'KB4598481'
@@ -224,7 +232,7 @@ Switch ($os) {
         $installHash = @{
             ssu =              'KB5001399'
             patchKBs =         $1507PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004249-x86_3011a800a44f3a2bd0d2baedb7a2f21dfc71c10e.msu'
+            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/08/windows10.0-kb5005040-x86_b6cbcefdb22b22a3a8841420d32af34d633a5c7d.msu'
             ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001399-x64_d33c5bf98f9c323bdfd3d7103a5215cb874221a1.msu'
         }
     }
@@ -232,7 +240,7 @@ Switch ($os) {
         $installHash = @{
             ssu =              'KB5001399'
             patchKBs =         $1507PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004249-x64_38d93e844d6342c49b9df47247e54e60a41e4bb9.msu'
+            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/08/windows10.0-kb5005040-x64_c9bb0618b0e9b1a50151e38796cd954923d0e202.msu'
             ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001399-x86_e3fe821338f8dcc5b9abc712ce940f34b6ce4f9e.msu'
         }
     }
@@ -240,7 +248,7 @@ Switch ($os) {
         $installHash = @{
             ssu =              'KB5001402'
             patchKBs =         $1607PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004238-x86_8d000fa9d73ffb093affc1ab1f20270f6d5abdf2.msu'
+            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/08/windows10.0-kb5005043-x86_7e72b64b264e89ec87cf35af180b43c879b3ef5b.msu'
             ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001402-x86_27a769112966bdc171f5f300bfd4819f02941f5a.msu'
         }
     }
@@ -248,7 +256,7 @@ Switch ($os) {
         $installHash = @{
             ssu =              'KB5001402'
             patchKBs =         $1607PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004238-x64_e3dd1cf22b1146f2469ef31f5fec0f47c8b5960b.msu'
+            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/08/windows10.0-kb5005043-x64_6e39252b88646ca55582da59e6f86a021d8b6ddd.msu'
             ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001402-x64_0108fcc32c0594f8578c3787babb7d84e6363864.msu'
         }
     }
@@ -256,48 +264,48 @@ Switch ($os) {
         $installHash = @{
             ssu =              'KB5001402'
             patchKBs =         $1607PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004238-x64_e3dd1cf22b1146f2469ef31f5fec0f47c8b5960b.msu'
+            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/08/windows10.0-kb5005043-x64_6e39252b88646ca55582da59e6f86a021d8b6ddd.msu'
             ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001402-x64_0108fcc32c0594f8578c3787babb7d84e6363864.msu'
         }
     }
     '1809_32-bit' {
         $installHash = @{
-            ssu =              'KB5003711'
+            ssu =              'KB5005112'
             patchKBs =         $1809PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004244-x86_f3b02d749e702248c4932721f5f58c2fc6378684.msu'
-            ssuUrl =           'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/06/windows10.0-kb5003711-x86_70a7ef9f67506eaeac5ae1747e90220e04e22492.msu'
+            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/08/windows10.0-kb5005030-x86_493fae3f27c82ab210f8bd408e89bc07aea5f5de.msu'
+            ssuUrl =           'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/08/windows10.0-kb5005112-x86_9c52dee3181a27bdc2a3f7dbbc8391c081c6871d.msu'
         }
     }
     '1809_64-bit' {
         $installHash = @{
-            ssu =              'KB5003711'
+            ssu =              'KB5005112'
             patchKBs =         $1809PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004244-x64_5685623313a6de061e0c42fed3391c29750a6b1b.msu'
-            ssuUrl =           'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/06/windows10.0-kb5003711-x64_577dc9cfe2e84d23b193aae2678b12e777fc7e55.msu'
+            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/08/windows10.0-kb5005030-x64_222160abfb75f543a693ca773dbcd0553ace6f03.msu'
+            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/08/windows10.0-kb5005112-x64_81d09dc6978520e1a6d44b3b15567667f83eba2c.msu'
         }
     }
     '2019' {
         $installHash = @{
-            ssu =              'KB5003711'
+            ssu =              'KB5005112'
             patchKBs =         $1809PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004244-x64_5685623313a6de061e0c42fed3391c29750a6b1b.msu'
-            ssuUrl =           'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/06/windows10.0-kb5003711-x64_577dc9cfe2e84d23b193aae2678b12e777fc7e55.msu'
+            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/08/windows10.0-kb5005030-x64_222160abfb75f543a693ca773dbcd0553ace6f03.msu'
+            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/08/windows10.0-kb5005112-x64_81d09dc6978520e1a6d44b3b15567667f83eba2c.msu'
         }
     }
     '1909_32-bit' {
         $installHash = @{
-            ssu =              'KB5004748'
+            ssu =              'KB5005412'
             patchKBs =         $1909PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004245-x86_1ff53f72381912f791e0a1a5fa3e2bbf41bdcf23.msu'
-            ssuUrl =           'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004748-x86_e456b8de1221c6e9ecfd9083fd3dbe2034325559.msu'
+            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/08/windows10.0-kb5005031-x86_38c48394e2f3c067febbdd0219d37d38545715d8.msu'
+            ssuUrl =           'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/08/windows10.0-kb5005412-x86_98f99f0aee4af93a076e5beeb72bf979c4b41f64.msu'
         }
     }
     '1909_64-bit' {
         $installHash = @{
-            ssu =              'KB5004748'
+            ssu =              'KB5005412'
             patchKBs =         $1909PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004245-x64_1a7054d81cab082980ad25de1395987b94a79893.msu'
-            ssuUrl =           'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004748-x64_2327ee6b541a2665817cc211f2fb832cc98031ac.msu'
+            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/08/windows10.0-kb5005031-x64_82d8a430666e65347948420466a0bcfd6c28e344.msu'
+            ssuUrl =           'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/08/windows10.0-kb5005412-x64_228ca7ad27c8f60174513607839c07686490e1e4.msu'
         }
     }
     '2004_32-bit' {
@@ -320,7 +328,7 @@ Switch ($os) {
         $installHash = @{
             ssu =              $2004AndNewerSsuKb
             patchKBs =         $2004AndNewerPatchKbs
-            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x64_9a7c569f5656d99533e9e945e8063251758ce4c0.msu'
+            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/08/windows10.0-kb5005033-x86_d5b969d54b3155cca9ad2e36565e1d8603aab21a.msu'
             ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x86_32286dd2d08021ce7ce35ee4855beb81c8d5f09e.msu'
         }
     }
@@ -328,7 +336,7 @@ Switch ($os) {
         $installHash = @{
             ssu =              $2004AndNewerSsuKb
             patchKBs =         $2004AndNewerPatchKbs
-            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x64_9a7c569f5656d99533e9e945e8063251758ce4c0.msu'
+            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/08/windows10.0-kb5005033-x64_ebab415d7a65f0b33f93e9a30875d74baa8930a7.msu'
             ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x64_749fe79fd2e31b145de37c2f9ebf4f711d174dc2.msu'
         }
     }
@@ -337,7 +345,7 @@ Switch ($os) {
         $installHash = @{
             ssu =              $Null
             patchKBs =         $2004AndNewerPatchKbs
-            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x64_9a7c569f5656d99533e9e945e8063251758ce4c0.msu'
+            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/08/windows10.0-kb5005033-x86_d5b969d54b3155cca9ad2e36565e1d8603aab21a.msu'
             ssuUrl =           $Null
         }
     }
@@ -345,7 +353,7 @@ Switch ($os) {
         $installHash = @{
             ssu =              $Null
             patchKBs =         $2004AndNewerPatchKbs
-            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x64_9a7c569f5656d99533e9e945e8063251758ce4c0.msu'
+            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/08/windows10.0-kb5005033-x64_ebab415d7a65f0b33f93e9a30875d74baa8930a7.msu'
             ssuUrl =           $Null
         }
     }

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -405,7 +405,7 @@ function Apply-Mitigation {
     If (Test-MitigationApplied) {
         [array]$out += "SYSTEM permissions were successfully set to DENY on the driver folders for the spooler service."
     } Else {
-        [array]$out += "There was a problem restricting permission on the spooler driver folder. Output: $Error"
+        [array]$out += "There was a problem restricting permission on the spooler driver folder. Output: $($Error[0])"
     }
 
     <#
@@ -438,7 +438,7 @@ function Apply-Mitigation {
         [array]$out += "The Microsoft-Windows-PrintService/Operational log has no events to report!"
     }
 
-    [array]$out += "Full error output: $Error"
+    [array]$out += "Full error output: $($Error[0])"
 
     return $out -join "`n"
 }
@@ -496,7 +496,7 @@ function Install-Patch (
             (New-Object System.Net.WebClient).DownloadFile($PatchUrl, $patchPath)
         } Catch {
             # Couldn't download. Exit early.
-            $out += "There was an error downloading the patch from $PatchUrl -> $Error"
+            $out += "There was an error downloading the patch from $PatchUrl -> $($Error[0])"
             Return $out -join "`n"
         }
 
@@ -520,7 +520,7 @@ function Install-Patch (
         Start-Process -FilePath wusa.exe -ArgumentList """$patchPath"" /quiet /norestart /log:""$patchDir\$($PatchKb)-InstallLog.evt""" -Wait
     } Catch {
         # Installation failed.
-        $out += "Installation failed."
+        $out += "Installation failed. Full error output: $($Error[0])"
     }
 
     # If patch installed successfully

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -102,6 +102,7 @@ If ($osName -like 'Microsoft Windows Server 2008*' -and $osName -notlike '*R2*')
 
 <# ------------------------ Hash Tables and Arrays for Days (setting up download URLs and applicable KB numbers) ------------------------------------- #>
 
+# Also applies to 2008r2
 $win7PatchKbs = @(
     'KB5004951'
 )
@@ -110,6 +111,7 @@ $2008PatchKbs = @(
     'KB5004959'
 )
 
+# Also applies to 2012r2
 $8PatchKbs = @(
     'KB5004958'
 )
@@ -120,6 +122,7 @@ $1507PatchKbs = @(
     'KB5005040'
 )
 
+# Also applies to server 2016
 $1607PatchKbs = @(
     'KB5004948',
     'KB5004238',
@@ -127,6 +130,7 @@ $1607PatchKbs = @(
     'KB5005043'
 )
 
+# Also applies to server 2019
 $1809PatchKbs = @(
     'KB5004947',
     'KB5004244',

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -150,37 +150,40 @@ $2004AndNewerPatchKbs = @(
     'KB5005033'
 )
 
+$msDPath = 'http://download.windowsupdate.com/d/msdownload/update/software/secu'
+$msCPath = 'http://download.windowsupdate.com/c/msdownload/update/software/secu'
+
 Switch ($os) {
     '7_32-bit' {
         $installHash = @{
             ssu =              'KB5004378'
             patchKBs =         $win7PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004951-x86_09808f3b8a74ce862f6e21ba36617c5b9bd53a3d.msu'
-            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004378-x86_7f71df13245adc8c835fccdeba92303b08e26a10.msu'
+            patchUrl =         "$msDPath/2021/07/windows6.1-kb5004951-x86_09808f3b8a74ce862f6e21ba36617c5b9bd53a3d.msu"
+            ssuUrl =           "$msDPath/2021/07/windows6.1-kb5004378-x86_7f71df13245adc8c835fccdeba92303b08e26a10.msu"
         }
     }
     '7_64-bit' {
         $installHash = @{
             ssu =              'KB5004378'
             patchKBs =         $win7PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.1-kb5004951-x64_2fcf9eaa66615884884cc1cb9f75fc96294cbf2a.msu'
-            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004378-x64_e295e0dfb732d1d4712c6aa5ac72aa28a7067359.msu'
+            patchUrl =         "$msCPath/2021/07/windows6.1-kb5004951-x64_2fcf9eaa66615884884cc1cb9f75fc96294cbf2a.msu"
+            ssuUrl =           "$msDPath/2021/07/windows6.1-kb5004378-x64_e295e0dfb732d1d4712c6aa5ac72aa28a7067359.msu"
         }
     }
     '2008r2' {
         $installHash = @{
             ssu =              'KB5004378'
             patchKBs =         $win7PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.1-kb5004951-x64_2fcf9eaa66615884884cc1cb9f75fc96294cbf2a.msu'
-            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004378-x64_e295e0dfb732d1d4712c6aa5ac72aa28a7067359.msu'
+            patchUrl =         "$msCPath/2021/07/windows6.1-kb5004951-x64_2fcf9eaa66615884884cc1cb9f75fc96294cbf2a.msu"
+            ssuUrl =           "$msDPath/2021/07/windows6.1-kb5004378-x64_e295e0dfb732d1d4712c6aa5ac72aa28a7067359.msu"
         }
     }
     '2008_32-bit' {
         $installHash = @{
             ssu =              'KB4580971'
             patchKBs =         $2008PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.0-kb5004959-x86_7d5c62a788b49b296de559b792a8e1cd5b3fad2d.msu'
-            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2020/10/windows6.0-kb4580971-x86_5a4cf976c650cf9b6a0800aaf6016726f4b08c7d.msu'
+            patchUrl =         "$msCPath/2021/07/windows6.0-kb5004959-x86_7d5c62a788b49b296de559b792a8e1cd5b3fad2d.msu"
+            ssuUrl =           "$msDPath/2020/10/windows6.0-kb4580971-x86_5a4cf976c650cf9b6a0800aaf6016726f4b08c7d.msu"
         }
 
     }
@@ -188,39 +191,39 @@ Switch ($os) {
         $installHash = @{
             ssu =              'KB4580971'
             patchKBs =         $2008PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.0-kb5004959-x64_7bfadd426a5764d3a2886afbb73f727fae5e0f67.msu'
-            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2020/10/windows6.0-kb4580971-x64_619424830431f3fba3c6d086b5dbe3e1ddf42f1f.msu'
+            patchUrl =         "$msCPath/2021/07/windows6.0-kb5004959-x64_7bfadd426a5764d3a2886afbb73f727fae5e0f67.msu"
+            ssuUrl =           "$msDPath/2020/10/windows6.0-kb4580971-x64_619424830431f3fba3c6d086b5dbe3e1ddf42f1f.msu"
         }
     }
     '8.1_32-bit' {
         $installHash = @{
             ssu =              'KB5001403'
             patchKBs =         $8PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x86_ee2308010d7605cad53e19a1bc762d85d044d88d.msu'
-            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8.1-kb5001403-x86_c59ac03777801436fa01dbf341f164a709ce8f8a.msu'
+            patchUrl =         "$msCPath/2021/07/windows8.1-kb5004958-x86_ee2308010d7605cad53e19a1bc762d85d044d88d.msu"
+            ssuUrl =           "$msDPath/2021/04/windows8.1-kb5001403-x86_c59ac03777801436fa01dbf341f164a709ce8f8a.msu"
         }
     }
     '8.1_64-bit' {
         $installHash = @{
             ssu =              'KB5001403'
             patchKBs =         $8PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x64_8b73440b9c53bcea2660d9409b6ad3920f104cd2.msu'
-            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8.1-kb5001403-x64_7f15c4b281f38d43475abb785a32dbaf0355bad5.msu'
+            patchUrl =         "$msCPath/2021/07/windows8.1-kb5004958-x64_8b73440b9c53bcea2660d9409b6ad3920f104cd2.msu"
+            ssuUrl =           "$msDPath/2021/04/windows8.1-kb5001403-x64_7f15c4b281f38d43475abb785a32dbaf0355bad5.msu"
         }
     }
     '2012r2' {
         $installHash = @{
             ssu =              'KB5001403'
             patchKBs =         $8PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x64_8b73440b9c53bcea2660d9409b6ad3920f104cd2.msu'
-            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8.1-kb5001403-x64_7f15c4b281f38d43475abb785a32dbaf0355bad5.msu'
+            patchUrl =         "$msCPath/2021/07/windows8.1-kb5004958-x64_8b73440b9c53bcea2660d9409b6ad3920f104cd2.msu"
+            ssuUrl =           "$msDPath/2021/04/windows8.1-kb5001403-x64_7f15c4b281f38d43475abb785a32dbaf0355bad5.msu"
         }
     }
     '2012' {
         $installHash = @{
             ssu =              'KB5001401'
-            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows8-rt-kb5004960-x64_15b7362a1146198852b2be37c4997f81e16495b6.msu'
-            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8-rt-kb5001401-x64_1027ae2c9888c2dfe0caadeafc506b3012789c56.msu'
+            patchUrl =         "$msDPath/2021/07/windows8-rt-kb5004960-x64_15b7362a1146198852b2be37c4997f81e16495b6.msu"
+            ssuUrl =           "$msDPath/2021/04/windows8-rt-kb5001401-x64_1027ae2c9888c2dfe0caadeafc506b3012789c56.msu"
             patchKBs = @(
                 'KB5004960'
             )
@@ -232,112 +235,112 @@ Switch ($os) {
         $installHash = @{
             ssu =              'KB5001399'
             patchKBs =         $1507PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/08/windows10.0-kb5005040-x86_b6cbcefdb22b22a3a8841420d32af34d633a5c7d.msu'
-            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001399-x64_d33c5bf98f9c323bdfd3d7103a5215cb874221a1.msu'
+            patchUrl =         "$msDPath/2021/08/windows10.0-kb5005040-x86_b6cbcefdb22b22a3a8841420d32af34d633a5c7d.msu"
+            ssuUrl =           "$msDPath/2021/04/windows10.0-kb5001399-x64_d33c5bf98f9c323bdfd3d7103a5215cb874221a1.msu"
         }
     }
     '1507_64-bit' {
         $installHash = @{
             ssu =              'KB5001399'
             patchKBs =         $1507PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/08/windows10.0-kb5005040-x64_c9bb0618b0e9b1a50151e38796cd954923d0e202.msu'
-            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001399-x86_e3fe821338f8dcc5b9abc712ce940f34b6ce4f9e.msu'
+            patchUrl =         "$msCPath/2021/08/windows10.0-kb5005040-x64_c9bb0618b0e9b1a50151e38796cd954923d0e202.msu"
+            ssuUrl =           "$msDPath/2021/04/windows10.0-kb5001399-x86_e3fe821338f8dcc5b9abc712ce940f34b6ce4f9e.msu"
         }
     }
     '1607_32-bit' {
         $installHash = @{
             ssu =              'KB5001402'
             patchKBs =         $1607PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/08/windows10.0-kb5005043-x86_7e72b64b264e89ec87cf35af180b43c879b3ef5b.msu'
-            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001402-x86_27a769112966bdc171f5f300bfd4819f02941f5a.msu'
+            patchUrl =         "$msDPath/2021/08/windows10.0-kb5005043-x86_7e72b64b264e89ec87cf35af180b43c879b3ef5b.msu"
+            ssuUrl =           "$msDPath/2021/04/windows10.0-kb5001402-x86_27a769112966bdc171f5f300bfd4819f02941f5a.msu"
         }
     }
     '1607_64-bit' {
         $installHash = @{
             ssu =              'KB5001402'
             patchKBs =         $1607PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/08/windows10.0-kb5005043-x64_6e39252b88646ca55582da59e6f86a021d8b6ddd.msu'
-            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001402-x64_0108fcc32c0594f8578c3787babb7d84e6363864.msu'
+            patchUrl =         "$msCPath/2021/08/windows10.0-kb5005043-x64_6e39252b88646ca55582da59e6f86a021d8b6ddd.msu"
+            ssuUrl =           "$msDPath/2021/04/windows10.0-kb5001402-x64_0108fcc32c0594f8578c3787babb7d84e6363864.msu"
         }
     }
     '2016' {
         $installHash = @{
             ssu =              'KB5001402'
             patchKBs =         $1607PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/08/windows10.0-kb5005043-x64_6e39252b88646ca55582da59e6f86a021d8b6ddd.msu'
-            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001402-x64_0108fcc32c0594f8578c3787babb7d84e6363864.msu'
+            patchUrl =         "$msCPath/2021/08/windows10.0-kb5005043-x64_6e39252b88646ca55582da59e6f86a021d8b6ddd.msu"
+            ssuUrl =           "$msDPath/2021/04/windows10.0-kb5001402-x64_0108fcc32c0594f8578c3787babb7d84e6363864.msu"
         }
     }
     '1809_32-bit' {
         $installHash = @{
             ssu =              'KB5005112'
             patchKBs =         $1809PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/08/windows10.0-kb5005030-x86_493fae3f27c82ab210f8bd408e89bc07aea5f5de.msu'
-            ssuUrl =           'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/08/windows10.0-kb5005112-x86_9c52dee3181a27bdc2a3f7dbbc8391c081c6871d.msu'
+            patchUrl =         "$msCPath/2021/08/windows10.0-kb5005030-x86_493fae3f27c82ab210f8bd408e89bc07aea5f5de.msu"
+            ssuUrl =           "$msCPath/2021/08/windows10.0-kb5005112-x86_9c52dee3181a27bdc2a3f7dbbc8391c081c6871d.msu"
         }
     }
     '1809_64-bit' {
         $installHash = @{
             ssu =              'KB5005112'
             patchKBs =         $1809PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/08/windows10.0-kb5005030-x64_222160abfb75f543a693ca773dbcd0553ace6f03.msu'
-            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/08/windows10.0-kb5005112-x64_81d09dc6978520e1a6d44b3b15567667f83eba2c.msu'
+            patchUrl =         "$msCPath/2021/08/windows10.0-kb5005030-x64_222160abfb75f543a693ca773dbcd0553ace6f03.msu"
+            ssuUrl =           "$msDPath/2021/08/windows10.0-kb5005112-x64_81d09dc6978520e1a6d44b3b15567667f83eba2c.msu"
         }
     }
     '2019' {
         $installHash = @{
             ssu =              'KB5005112'
             patchKBs =         $1809PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/08/windows10.0-kb5005030-x64_222160abfb75f543a693ca773dbcd0553ace6f03.msu'
-            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/08/windows10.0-kb5005112-x64_81d09dc6978520e1a6d44b3b15567667f83eba2c.msu'
+            patchUrl =         "$msCPath/2021/08/windows10.0-kb5005030-x64_222160abfb75f543a693ca773dbcd0553ace6f03.msu"
+            ssuUrl =           "$msDPath/2021/08/windows10.0-kb5005112-x64_81d09dc6978520e1a6d44b3b15567667f83eba2c.msu"
         }
     }
     '1909_32-bit' {
         $installHash = @{
             ssu =              'KB5005412'
             patchKBs =         $1909PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/08/windows10.0-kb5005031-x86_38c48394e2f3c067febbdd0219d37d38545715d8.msu'
-            ssuUrl =           'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/08/windows10.0-kb5005412-x86_98f99f0aee4af93a076e5beeb72bf979c4b41f64.msu'
+            patchUrl =         "$msCPath/2021/08/windows10.0-kb5005031-x86_38c48394e2f3c067febbdd0219d37d38545715d8.msu"
+            ssuUrl =           "$msCPath/2021/08/windows10.0-kb5005412-x86_98f99f0aee4af93a076e5beeb72bf979c4b41f64.msu"
         }
     }
     '1909_64-bit' {
         $installHash = @{
             ssu =              'KB5005412'
             patchKBs =         $1909PatchKbs
-            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/08/windows10.0-kb5005031-x64_82d8a430666e65347948420466a0bcfd6c28e344.msu'
-            ssuUrl =           'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/08/windows10.0-kb5005412-x64_228ca7ad27c8f60174513607839c07686490e1e4.msu'
+            patchUrl =         "$msCPath/2021/08/windows10.0-kb5005031-x64_82d8a430666e65347948420466a0bcfd6c28e344.msu"
+            ssuUrl =           "$msCPath/2021/08/windows10.0-kb5005412-x64_228ca7ad27c8f60174513607839c07686490e1e4.msu"
         }
     }
     '2004_32-bit' {
         $installHash = @{
             ssu =              $2004AndNewerSsuKb
             patchKBs =         $2004AndNewerPatchKbs
-            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/08/windows10.0-kb5005033-x86_d5b969d54b3155cca9ad2e36565e1d8603aab21a.msu'
-            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x86_32286dd2d08021ce7ce35ee4855beb81c8d5f09e.msu'
+            patchUrl =         "$msDPath/2021/08/windows10.0-kb5005033-x86_d5b969d54b3155cca9ad2e36565e1d8603aab21a.msu"
+            ssuUrl =           "$msDPath/2021/01/windows10.0-kb4598481-x86_32286dd2d08021ce7ce35ee4855beb81c8d5f09e.msu"
         }
     }
     '2004_64-bit' {
         $installHash = @{
             ssu =              $2004AndNewerSsuKb
             patchKBs =         $2004AndNewerPatchKbs
-            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/08/windows10.0-kb5005033-x64_ebab415d7a65f0b33f93e9a30875d74baa8930a7.msu'
-            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x64_749fe79fd2e31b145de37c2f9ebf4f711d174dc2.msu'
+            patchUrl =         "$msDPath/2021/08/windows10.0-kb5005033-x64_ebab415d7a65f0b33f93e9a30875d74baa8930a7.msu"
+            ssuUrl =           "$msDPath/2021/01/windows10.0-kb4598481-x64_749fe79fd2e31b145de37c2f9ebf4f711d174dc2.msu"
         }
     }
     '20H2_32-bit' {
         $installHash = @{
             ssu =              $2004AndNewerSsuKb
             patchKBs =         $2004AndNewerPatchKbs
-            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/08/windows10.0-kb5005033-x86_d5b969d54b3155cca9ad2e36565e1d8603aab21a.msu'
-            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x86_32286dd2d08021ce7ce35ee4855beb81c8d5f09e.msu'
+            patchUrl =         "$msDPath/2021/08/windows10.0-kb5005033-x86_d5b969d54b3155cca9ad2e36565e1d8603aab21a.msu"
+            ssuUrl =           "$msDPath/2021/01/windows10.0-kb4598481-x86_32286dd2d08021ce7ce35ee4855beb81c8d5f09e.msu"
         }
     }
     '20H2_64-bit' {
         $installHash = @{
             ssu =              $2004AndNewerSsuKb
             patchKBs =         $2004AndNewerPatchKbs
-            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/08/windows10.0-kb5005033-x64_ebab415d7a65f0b33f93e9a30875d74baa8930a7.msu'
-            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x64_749fe79fd2e31b145de37c2f9ebf4f711d174dc2.msu'
+            patchUrl =         "$msDPath/2021/08/windows10.0-kb5005033-x64_ebab415d7a65f0b33f93e9a30875d74baa8930a7.msu"
+            ssuUrl =           "$msDPath/2021/01/windows10.0-kb4598481-x64_749fe79fd2e31b145de37c2f9ebf4f711d174dc2.msu"
         }
     }
     # 21H1 doesn't currently have an SSU
@@ -345,7 +348,7 @@ Switch ($os) {
         $installHash = @{
             ssu =              $Null
             patchKBs =         $2004AndNewerPatchKbs
-            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/08/windows10.0-kb5005033-x86_d5b969d54b3155cca9ad2e36565e1d8603aab21a.msu'
+            patchUrl =         "$msDPath/2021/08/windows10.0-kb5005033-x86_d5b969d54b3155cca9ad2e36565e1d8603aab21a.msu"
             ssuUrl =           $Null
         }
     }
@@ -353,7 +356,7 @@ Switch ($os) {
         $installHash = @{
             ssu =              $Null
             patchKBs =         $2004AndNewerPatchKbs
-            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/08/windows10.0-kb5005033-x64_ebab415d7a65f0b33f93e9a30875d74baa8930a7.msu'
+            patchUrl =         "$msDPath/2021/08/windows10.0-kb5005033-x64_ebab415d7a65f0b33f93e9a30875d74baa8930a7.msu"
             ssuUrl =           $Null
         }
     }

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -4,7 +4,7 @@
     - Constants
     - Init vars
     - Gather info from environment
-    - Determine which patch is applicable
+    - Hash Tables and Arrays for Days (setting up download URLs and applicable KB numbers)
     - Mitigation helper functions
     - Answer important questions
     - Early exit points
@@ -16,6 +16,7 @@
 $driverPath = "$ENV:windir\System32\spool\drivers"
 $PnpRegPath = 'HKLM:\\SOFTWARE\Policies\Microsoft\Windows NT\Printers\PointAndPrint'
 $ltPath = "$ENV:windir\LTSvc"
+$printNightmarePath = "$ltPath\security\printnightmare"
 $patchDir = "$ltPath\Patching"
 
 <# ------------------------ Init vars ------------------------------------- #>
@@ -41,9 +42,6 @@ $restrictDriverInstallation = 0
 
 # Will hold saved pnp reg settings state if exists
 $originalPnpDisabledValue = ''
-
-$applicableUrl = ''
-$applicableKb = ''
 
 # possibly for future use.. can't find win10 example or way to test validity of approach
 # $ESUWin7Year1 = (Get-WmiObject softwarelicensingproduct -filter "ID='77db037b-95c3-48d7-a3ab-a9c6d41093e0'" | Select LicenseStatus)
@@ -102,181 +100,266 @@ If ($osName -like 'Microsoft Windows Server 2008*' -and $osName -notlike '*R2*')
     $os = "7_$osArch"
 }
 
-<# ------------------------ Determine which patch is applicable ------------------------------------- #>
+<# ------------------------ Hash Tables and Arrays for Days (setting up download URLs and applicable KB numbers) ------------------------------------- #>
+
+$win7PatchKbs = @(
+    'KB5004951'
+)
+
+$2008PatchKbs = @(
+    'KB5004959'
+)
+
+$8PatchKbs = @(
+    'KB5004958'
+)
+
+$1607PatchKbs = @(
+    'KB5004948',
+    'KB5004238'
+)
+
+$1809PatchKbs = @(
+    'KB5004947',
+    'KB5004244'
+)
+
+$1909PatchKbs = @(
+    'KB5004946',
+    'KB5004245'
+)
+
+$1507PatchKbs = @(
+    'KB5004950',
+    'KB5004249'
+)
+
+$2004AndNewerSsuKb = 'KB4598481'
+$2004AndNewerPatchKbs = @(
+    'KB5004945',
+    'KB5004237',
+    'KB5004296',
+    'KB5005033'
+)
 
 Switch ($os) {
     '7_32-bit' {
-        $kb =           'KB5004951'
-        $ssu =          'KB5004378'
-        $url =          'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004951-x86_09808f3b8a74ce862f6e21ba36617c5b9bd53a3d.msu'
-        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004378-x86_7f71df13245adc8c835fccdeba92303b08e26a10.msu'
+        $installHash = @{
+            ssu =              'KB5004378'
+            patchKBs =         $win7PatchKbs
+            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004951-x86_09808f3b8a74ce862f6e21ba36617c5b9bd53a3d.msu'
+            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004378-x86_7f71df13245adc8c835fccdeba92303b08e26a10.msu'
+        }
     }
     '7_64-bit' {
-        $kb =           'KB5004951'
-        $ssu =          'KB5004378'
-        $url =          'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.1-kb5004951-x64_2fcf9eaa66615884884cc1cb9f75fc96294cbf2a.msu'
-        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004378-x64_e295e0dfb732d1d4712c6aa5ac72aa28a7067359.msu'
-    }
-    '2008_32-bit' {
-        $kb =           'KB5004959'
-        $ssu =          'KB4580971'
-        $url =          'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.0-kb5004959-x86_7d5c62a788b49b296de559b792a8e1cd5b3fad2d.msu'
-        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2020/10/windows6.0-kb4580971-x86_5a4cf976c650cf9b6a0800aaf6016726f4b08c7d.msu'
-    }
-    '2008_64-bit' {
-        $kb =           'KB5004959'
-        $ssu =          'KB4580971'
-        $url =          'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.0-kb5004959-x64_7bfadd426a5764d3a2886afbb73f727fae5e0f67.msu'
-        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2020/10/windows6.0-kb4580971-x64_619424830431f3fba3c6d086b5dbe3e1ddf42f1f.msu'
+        $installHash = @{
+            ssu =              'KB5004378'
+            patchKBs =         $win7PatchKbs
+            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.1-kb5004951-x64_2fcf9eaa66615884884cc1cb9f75fc96294cbf2a.msu'
+            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004378-x64_e295e0dfb732d1d4712c6aa5ac72aa28a7067359.msu'
+        }
     }
     '2008r2' {
-        $kb =           'KB5004951'
-        $ssu =          'KB5004378'
-        $url =          'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.1-kb5004951-x64_2fcf9eaa66615884884cc1cb9f75fc96294cbf2a.msu'
-        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004378-x64_e295e0dfb732d1d4712c6aa5ac72aa28a7067359.msu'
+        $installHash = @{
+            ssu =              'KB5004378'
+            patchKBs =         $win7PatchKbs
+            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.1-kb5004951-x64_2fcf9eaa66615884884cc1cb9f75fc96294cbf2a.msu'
+            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows6.1-kb5004378-x64_e295e0dfb732d1d4712c6aa5ac72aa28a7067359.msu'
+        }
+    }
+    '2008_32-bit' {
+        $installHash = @{
+            ssu =              'KB4580971'
+            patchKBs =         $2008PatchKbs
+            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.0-kb5004959-x86_7d5c62a788b49b296de559b792a8e1cd5b3fad2d.msu'
+            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2020/10/windows6.0-kb4580971-x86_5a4cf976c650cf9b6a0800aaf6016726f4b08c7d.msu'
+        }
+
+    }
+    '2008_64-bit' {
+        $installHash = @{
+            ssu =              'KB4580971'
+            patchKBs =         $2008PatchKbs
+            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows6.0-kb5004959-x64_7bfadd426a5764d3a2886afbb73f727fae5e0f67.msu'
+            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2020/10/windows6.0-kb4580971-x64_619424830431f3fba3c6d086b5dbe3e1ddf42f1f.msu'
+        }
     }
     '8.1_32-bit' {
-        $kb =           'KB5004958'
-        $ssu =          'KB5001403'
-        $url =          'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x86_ee2308010d7605cad53e19a1bc762d85d044d88d.msu'
-        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8.1-kb5001403-x86_c59ac03777801436fa01dbf341f164a709ce8f8a.msu'
+        $installHash = @{
+            ssu =              'KB5001403'
+            patchKBs =         $8PatchKbs
+            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x86_ee2308010d7605cad53e19a1bc762d85d044d88d.msu'
+            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8.1-kb5001403-x86_c59ac03777801436fa01dbf341f164a709ce8f8a.msu'
+        }
     }
     '8.1_64-bit' {
-        $kb =           'KB5004958'
-        $ssu =          'KB5001403'
-        $url =          'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x64_8b73440b9c53bcea2660d9409b6ad3920f104cd2.msu'
-        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8.1-kb5001403-x64_7f15c4b281f38d43475abb785a32dbaf0355bad5.msu'
-    }
-    '2012' {
-        $kb =           'KB5004960'
-        $ssu =          'KB5001401'
-        $url =          'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows8-rt-kb5004960-x64_15b7362a1146198852b2be37c4997f81e16495b6.msu'
-        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8-rt-kb5001401-x64_1027ae2c9888c2dfe0caadeafc506b3012789c56.msu'
+        $installHash = @{
+            ssu =              'KB5001403'
+            patchKBs =         $8PatchKbs
+            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x64_8b73440b9c53bcea2660d9409b6ad3920f104cd2.msu'
+            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8.1-kb5001403-x64_7f15c4b281f38d43475abb785a32dbaf0355bad5.msu'
+        }
     }
     '2012r2' {
-        $kb =           'KB5004958'
-        $ssu =          'KB5001403'
-        $url =          'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x64_8b73440b9c53bcea2660d9409b6ad3920f104cd2.msu'
-        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8.1-kb5001403-x64_7f15c4b281f38d43475abb785a32dbaf0355bad5.msu'
+        $installHash = @{
+            ssu =              'KB5001403'
+            patchKBs =         $8PatchKbs
+            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows8.1-kb5004958-x64_8b73440b9c53bcea2660d9409b6ad3920f104cd2.msu'
+            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8.1-kb5001403-x64_7f15c4b281f38d43475abb785a32dbaf0355bad5.msu'
+        }
     }
-    '2016' {
-        $kb =           'KB5004948'
-        $cumulativeKb = 'KB5004238'
-        $ssu =          'KB5001402'
-        $cumulativeUrl ='http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004238-x64_e3dd1cf22b1146f2469ef31f5fec0f47c8b5960b.msu'
-        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001402-x64_0108fcc32c0594f8578c3787babb7d84e6363864.msu'
-    }
-    '2019' {
-        $kb =           'KB5004947'
-        $cumulativeKb = 'KB5004244'
-        $ssu =          'KB5003711'
-        $cumulativeUrl ='http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004244-x64_5685623313a6de061e0c42fed3391c29750a6b1b.msu'
-        $ssuUrl =       'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/06/windows10.0-kb5003711-x64_577dc9cfe2e84d23b193aae2678b12e777fc7e55.msu'
+    '2012' {
+        $installHash = @{
+            ssu =              'KB5001401'
+            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows8-rt-kb5004960-x64_15b7362a1146198852b2be37c4997f81e16495b6.msu'
+            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows8-rt-kb5001401-x64_1027ae2c9888c2dfe0caadeafc506b3012789c56.msu'
+            patchKBs = @(
+                'KB5004960'
+            )
+        }
+
     }
     # 1507-1809 KBs specify they're for Win10 LTSB, so they might be unlikely to install... Not sure how to check at the moment.. related to the ESU question..
     '1507_32-bit' {
-        $kb =           'KB5004950'
-        $cumulativeKb = 'KB5004249'
-        $ssu =          'KB5001399'
-        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004249-x86_3011a800a44f3a2bd0d2baedb7a2f21dfc71c10e.msu'
-        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001399-x64_d33c5bf98f9c323bdfd3d7103a5215cb874221a1.msu'
+        $installHash = @{
+            ssu =              'KB5001399'
+            patchKBs =         $1507PatchKbs
+            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004249-x86_3011a800a44f3a2bd0d2baedb7a2f21dfc71c10e.msu'
+            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001399-x64_d33c5bf98f9c323bdfd3d7103a5215cb874221a1.msu'
+        }
     }
     '1507_64-bit' {
-        $kb =           'KB5004950'
-        $cumulativeKb = 'KB5004249'
-        $ssu =          'KB5001399'
-        $cumulativeUrl ='http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004249-x64_38d93e844d6342c49b9df47247e54e60a41e4bb9.msu'
-        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001399-x86_e3fe821338f8dcc5b9abc712ce940f34b6ce4f9e.msu'
+        $installHash = @{
+            ssu =              'KB5001399'
+            patchKBs =         $1507PatchKbs
+            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004249-x64_38d93e844d6342c49b9df47247e54e60a41e4bb9.msu'
+            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001399-x86_e3fe821338f8dcc5b9abc712ce940f34b6ce4f9e.msu'
+        }
     }
     '1607_32-bit' {
-        $kb =           'KB5004948'
-        $cumulativeKb = 'KB5004238'
-        $ssu =          'KB5001402'
-        $cumulativeUrl ='http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004238-x86_8d000fa9d73ffb093affc1ab1f20270f6d5abdf2.msu'
-        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001402-x86_27a769112966bdc171f5f300bfd4819f02941f5a.msu'
+        $installHash = @{
+            ssu =              'KB5001402'
+            patchKBs =         $1607PatchKbs
+            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004238-x86_8d000fa9d73ffb093affc1ab1f20270f6d5abdf2.msu'
+            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001402-x86_27a769112966bdc171f5f300bfd4819f02941f5a.msu'
+        }
     }
     '1607_64-bit' {
-        $kb =           'KB5004948'
-        $cumulativeKb = 'KB5004238'
-        $ssu =          'KB5001402'
-        $cumulativeUrl ='http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004238-x64_e3dd1cf22b1146f2469ef31f5fec0f47c8b5960b.msu'
-        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001402-x64_0108fcc32c0594f8578c3787babb7d84e6363864.msu'
+        $installHash = @{
+            ssu =              'KB5001402'
+            patchKBs =         $1607PatchKbs
+            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004238-x64_e3dd1cf22b1146f2469ef31f5fec0f47c8b5960b.msu'
+            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001402-x64_0108fcc32c0594f8578c3787babb7d84e6363864.msu'
+        }
+    }
+    '2016' {
+        $installHash = @{
+            ssu =              'KB5001402'
+            patchKBs =         $1607PatchKbs
+            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004238-x64_e3dd1cf22b1146f2469ef31f5fec0f47c8b5960b.msu'
+            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/04/windows10.0-kb5001402-x64_0108fcc32c0594f8578c3787babb7d84e6363864.msu'
+        }
     }
     '1809_32-bit' {
-        $kb =           'KB5004947'
-        $cumulativeKb = 'KB5004244'
-        $ssu =          'KB5003711'
-        $cumulativeUrl ='http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004244-x86_f3b02d749e702248c4932721f5f58c2fc6378684.msu'
-        $ssuUrl =       'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/06/windows10.0-kb5003711-x86_70a7ef9f67506eaeac5ae1747e90220e04e22492.msu'
+        $installHash = @{
+            ssu =              'KB5003711'
+            patchKBs =         $1809PatchKbs
+            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004244-x86_f3b02d749e702248c4932721f5f58c2fc6378684.msu'
+            ssuUrl =           'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/06/windows10.0-kb5003711-x86_70a7ef9f67506eaeac5ae1747e90220e04e22492.msu'
+        }
     }
     '1809_64-bit' {
-        $kb =           'KB5004947'
-        $cumulativeKb = 'KB5004244'
-        $ssu =          'KB5003711'
-        $cumulativeUrl ='http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004244-x64_5685623313a6de061e0c42fed3391c29750a6b1b.msu'
-        $ssuUrl =       'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/06/windows10.0-kb5003711-x64_577dc9cfe2e84d23b193aae2678b12e777fc7e55.msu'
+        $installHash = @{
+            ssu =              'KB5003711'
+            patchKBs =         $1809PatchKbs
+            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004244-x64_5685623313a6de061e0c42fed3391c29750a6b1b.msu'
+            ssuUrl =           'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/06/windows10.0-kb5003711-x64_577dc9cfe2e84d23b193aae2678b12e777fc7e55.msu'
+        }
+    }
+    '2019' {
+        $installHash = @{
+            ssu =              'KB5003711'
+            patchKBs =         $1809PatchKbs
+            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004244-x64_5685623313a6de061e0c42fed3391c29750a6b1b.msu'
+            ssuUrl =           'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/06/windows10.0-kb5003711-x64_577dc9cfe2e84d23b193aae2678b12e777fc7e55.msu'
+        }
     }
     '1909_32-bit' {
-        $kb =           'KB5004946'
-        $cumulativeKb = 'KB5004245'
-        $ssu =          'KB5004748'
-        $cumulativeUrl ='http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004245-x86_1ff53f72381912f791e0a1a5fa3e2bbf41bdcf23.msu'
-        $ssuUrl =       'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004748-x86_e456b8de1221c6e9ecfd9083fd3dbe2034325559.msu'
+        $installHash = @{
+            ssu =              'KB5004748'
+            patchKBs =         $1909PatchKbs
+            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004245-x86_1ff53f72381912f791e0a1a5fa3e2bbf41bdcf23.msu'
+            ssuUrl =           'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004748-x86_e456b8de1221c6e9ecfd9083fd3dbe2034325559.msu'
+        }
     }
     '1909_64-bit' {
-        $kb =           'KB5004946'
-        $cumulativeKb = 'KB5004245'
-        $ssu =          'KB5004748'
-        $cumulativeUrl ='http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004245-x64_1a7054d81cab082980ad25de1395987b94a79893.msu'
-        $ssuUrl =       'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004748-x64_2327ee6b541a2665817cc211f2fb832cc98031ac.msu'
+        $installHash = @{
+            ssu =              'KB5004748'
+            patchKBs =         $1909PatchKbs
+            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/07/windows10.0-kb5004245-x64_1a7054d81cab082980ad25de1395987b94a79893.msu'
+            ssuUrl =           'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004748-x64_2327ee6b541a2665817cc211f2fb832cc98031ac.msu'
+        }
     }
     '2004_32-bit' {
-        $kb =           'KB5004945'
-        $cumulativeKb = 'KB5004237'
-        $ssu =          'KB4598481'
-        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x86_571a793bba0b7d881e7076f83b7f1245ff41011f.msu'
-        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x86_32286dd2d08021ce7ce35ee4855beb81c8d5f09e.msu'
+        $installHash = @{
+            ssu =              $2004AndNewerSsuKb
+            patchKBs =         $2004AndNewerPatchKbs
+            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/08/windows10.0-kb5005033-x86_d5b969d54b3155cca9ad2e36565e1d8603aab21a.msu'
+            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x86_32286dd2d08021ce7ce35ee4855beb81c8d5f09e.msu'
+        }
     }
     '2004_64-bit' {
-        $kb =           'KB5004945'
-        $cumulativeKb = 'KB5004237'
-        $ssu =          'KB4598481'
-        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x64_9a7c569f5656d99533e9e945e8063251758ce4c0.msu'
-        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x64_749fe79fd2e31b145de37c2f9ebf4f711d174dc2.msu'
+        $installHash = @{
+            ssu =              $2004AndNewerSsuKb
+            patchKBs =         $2004AndNewerPatchKbs
+            patchUrl =         'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/08/windows10.0-kb5005033-x64_ebab415d7a65f0b33f93e9a30875d74baa8930a7.msu'
+            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x64_749fe79fd2e31b145de37c2f9ebf4f711d174dc2.msu'
+        }
     }
     '20H2_32-bit' {
-        $kb =           'KB5004945'
-        $cumulativeKb = 'KB5004237'
-        $ssu =          'KB4598481'
-        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x86_571a793bba0b7d881e7076f83b7f1245ff41011f.msu'
-        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x86_32286dd2d08021ce7ce35ee4855beb81c8d5f09e.msu'
+        $installHash = @{
+            ssu =              $2004AndNewerSsuKb
+            patchKBs =         $2004AndNewerPatchKbs
+            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x64_9a7c569f5656d99533e9e945e8063251758ce4c0.msu'
+            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x86_32286dd2d08021ce7ce35ee4855beb81c8d5f09e.msu'
+        }
     }
     '20H2_64-bit' {
-        $kb =           'KB5004945'
-        $cumulativeKb = 'KB5004237'
-        $ssu =          'KB4598481'
-        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x64_9a7c569f5656d99533e9e945e8063251758ce4c0.msu'
-        $ssuUrl =       'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x64_749fe79fd2e31b145de37c2f9ebf4f711d174dc2.msu'
+        $installHash = @{
+            ssu =              $2004AndNewerSsuKb
+            patchKBs =         $2004AndNewerPatchKbs
+            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x64_9a7c569f5656d99533e9e945e8063251758ce4c0.msu'
+            ssuUrl =           'http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows10.0-kb4598481-x64_749fe79fd2e31b145de37c2f9ebf4f711d174dc2.msu'
+        }
     }
-    # 21H12 doesn't currently have an SSU
+    # 21H1 doesn't currently have an SSU
     '21H1_32-bit' {
-        $kb =           'KB5004945'
-        $cumulativeKb = 'KB5004237'
-        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x86_571a793bba0b7d881e7076f83b7f1245ff41011f.msu'
+        $installHash = @{
+            ssu =              $Null
+            patchKBs =         $2004AndNewerPatchKbs
+            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x64_9a7c569f5656d99533e9e945e8063251758ce4c0.msu'
+            ssuUrl =           $Null
+        }
     }
     '21H1_64-bit' {
-        $kb =           'KB5004945'
-        $cumulativeKb = 'KB5004237'
-        $cumulativeUrl ='http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x64_9a7c569f5656d99533e9e945e8063251758ce4c0.msu'
+        $installHash = @{
+            ssu =              $Null
+            patchKBs =         $2004AndNewerPatchKbs
+            patchUrl =         'http://download.windowsupdate.com/c/msdownload/update/software/secu/2021/07/windows10.0-kb5004237-x64_9a7c569f5656d99533e9e945e8063251758ce4c0.msu'
+            ssuUrl =           $Null
+        }
     }
-    Default   {
-        $kb = $Null
-        $cumulativeKb = $Null
-        $ssu = $Null
-        $cumulativeUrl = $Null
-        $ssuUrl = $Null
+    Default {
+        $installHash = @{
+            patchKBs = @()
+            patchUrl = $Null
+            ssuUrl = $Null
+            ssu = $Null
+        }
     }
 }
+
+$successfulInstallationMarkerPath = "$printNightmarePath\$os-$($installHash.patchKBs[-1]).txt"
 
 <# ------------------------ Mitigation helper functions ------------------------------------- #>
 
@@ -451,15 +534,12 @@ function Get-PnpFeaturesDisabled {
 <# ------------------------ Answer important questions ------------------------------------- #>
 
 # If OS has compatible patch
-If ($os -and ($cumulativeKb -or $kb)) {
+If ($os -and $installHash.patchKbs.length) {
     $compatibleOs = 1
 
     # ..and an available hotfix OR cumulative is installed
-    If ($cumulativeKb -and (Get-Hotfix -Id $cumulativeKb -EA 0)) {
-        $patchApplied = 1
-    }
-
-    If ($kb -and (Get-HotFix -Id $kb -EA 0)) {
+    $installedPatches = $installHash.patchKBs | ForEach-Object { Get-Hotfix -Id $_ -EA 0 }
+    If ($installedPatches) {
         $patchApplied = 1
     }
 }
@@ -477,16 +557,15 @@ $restrictDriverInstallation = (Get-ItemProperty -Path $PnpRegPath -Name "Restric
 
 # Previous installation attempted?
 # Also need to check for previous versions of file... don't want to install if they exist either.
-$previousInstallAttemptPathOs = "$ltPath\security\printnightmare\$os.txt"
-If ($cumulativeKb) {
-    $previousInstallAttemptPathWithKb = "$ltPath\security\printnightmare\$os-$cumulativeKb.txt"
-} Else {
-    $previousInstallAttemptPathWithKb = "$ltPath\security\printnightmare\$os-$kb.txt"
+# $Null option included because some PCs in a previous version of the script did not have $hotfixKb set and could have resulted in that file name
+$previousInstallAttemptPaths = @("$printNightmarePath\$os.txt", "$printNightmarePath\$os-$Null.txt")
+$installHash.patchKBs | ForEach-Object {
+    $previousInstallAttemptPaths += "$printNightmarePath\$os-$_.txt"
 }
 
 # If pnp reg settings exist and are enabled, in case an issue is caused and we need to know if pnp reg settings
 # were originally enabled, save initial state
-$pnpStatePath = "$ltPath\security\printnightmare\pnpState.txt"
+$pnpStatePath = "$printNightmarePath\pnpState.txt"
 
 # If no file, no previous state is saved
 If (!(Test-Path -Path $pnpStatePath)) {
@@ -521,7 +600,7 @@ If ((Get-WMIObject win32_service -Filter "Name='spooler'").StartMode -eq 'Disabl
     Return
 }
 
-# If $excludeFromMitigation is 1, don't mitigate. Exit early, sending back answers.
+# If $excludeFromMitigation is 1, don't mitigate. Exit early.
 If ($excludeFromMitigation -eq 1) {
     $output += "This machine was excluded from mitigation"
 
@@ -536,13 +615,17 @@ If ($excludeFromMitigation -eq 1) {
     Return
 }
 
-# $Null option included because some PCs in a previous version of the script did not have $kb set and could have resulted in that file name
-$previousInstallAttempted = (Test-Path -Path $previousInstallAttemptPathOs) -or (Test-Path -Path $previousInstallAttemptPathWithKb) -or (Test-Path -Path "$ltPath\security\printnightmare\$os-$Null.txt")
+$previousInstallAttempted = (Test-Path -Path $previousInstallAttemptPaths) -contains $true
 
-# If patch is not applied, the OS is compatible, but this has been tried before...
+# If patch is not applied, the OS is compatible, but this has been tried before... it apparently did not succeed
 If ((!$patchApplied -and $compatibleOs) -and $previousInstallAttempted) {
-    # This has tried to install before at apparently did not succeed
-    $output += "This installation was attempted in the past and failed. Not trying again."
+    $previousInstallAttemptPaths | ForEach-Object {
+        If (Test-Path -Path $_) {
+            $output += "Previous installation detected via existence of $_"
+        }
+    }
+
+    $output += "Due to previous failed installation attempt, assuming this is an unsupported OS without ESU. Not trying installation of $($installHash.patchKBs[-1])."
 
     # Reapply mitigation
     $output += Apply-Mitigation
@@ -579,10 +662,12 @@ If (!$compatibleOs) {
 
 # If patch is not installed, install it
 If (!$patchApplied) {
+    $ssu = $installHash.ssu
+
     If ($ssu) {
         # SSU exists for this OS, let's see if it's already installed and if not, install it
         If (!(Get-HotFix -Id $ssu -EA 0)) {
-            $ssuOutput = Install-Patch -PatchKb $ssu -PatchUrl $ssuUrl
+            $ssuOutput = Install-Patch -PatchKb $ssu -PatchUrl $installHash.ssuUrl
         } Else {
             $ssuOutput = "SSU update $ssu is already installed."
         }
@@ -598,39 +683,28 @@ If (!$patchApplied) {
 
     $output += "Removed mitigation temporarily during installation."
 
-    # Download cumulative if available, otherwise download hotfix
-    If ($cumulativeUrl) {
-        $applicableUrl = $cumulativeUrl
-    } Else {
-        $applicableUrl = $url
-    }
-
-    # Install cumulative if available, otherwise install hotfix
-    If ($cumulativeKb) {
-        $applicableKb = $cumulativeKb
-    } Else {
-        $applicableKb = $
-    }
-
-    $output += Install-Patch -PatchKb $applicableKb -PatchUrl $applicableUrl
+    # Install the KB. Always install the last KB in the list, should be the newest.
+    $output += Install-Patch -PatchKb $installHash.patchKBs[-1] -PatchUrl $installHash.patchUrl
 
     # If the patch was sucessfully installed
     If ($output -like "*!SUCCESS*") {
         $patchApplied = 1
-        New-Item $previousInstallAttemptPathOs -ItemType File -Force | Out-Null
+        New-Item $successfulInstallationMarkerPath -ItemType File -Force | Out-Null
     } Else {
         $patchApplied = 0
     }
 
+    # We want the success message from the patch install at the beginning, so attach ssuOutput afterward
     $output += $ssuOutput
 }
 
+# If patch is installed
 If ($patchApplied) {
-    # Patch is installed
-
-    # If file marking successful installation doesn't exist, create it
-    If (!(Test-Path -Path $previousInstallAttemptPathOs)) {
-        New-Item $previousInstallAttemptPathOs -ItemType File -Force | Out-Null
+    # A patch is applied. If file marking successful installation doesn't exist, create it
+    If (!$previousInstallAttempted) {
+        $installedPatches | ForEach-Object {
+            New-Item "$printNightmarePath\$os-$($_.HotFixID).txt" -ItemType File -Force | Out-Null
+        }
     }
 
     If ($restrictDriverInstallation -eq 1) {


### PR DESCRIPTION
This was a bear... Ready for review. I bet you're getting tired of reviewing giant changes to this stupid script @wmmatt 

- Changes data format of KB numbers and download URLs to using arrays and hash tables instead of static variable names to more easily check for existence of multiple KBs that all make the machine not vulnerable. It will also be easy to add new KBs in the future.
- Includes new superseding KBs for patches and SSUs anywhere applicable. All KBs are in the list, but upon installation, the last KB in the array will be used, so it is important that we always add the newest KB to the bottom of the array.
- When checking for failed past installations, it will halt the script on ANY applicable KB having failed in the past on that particular windows build. If the build changes (i.e. 1909 to 20h2), it will reassess.