### PR TITLE
Update CVE-2021_34527_PrintNightmare_Patch.ps1

### DIFF
--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -396,16 +396,20 @@ function Apply-Mitigation {
     $BadEventId = 316
     [array]$out
 
-    # Needs testing. Throws error in some cases. I think just in powershell 7? Alternative would be `$Acl = Get-Acl $driverPath`
-    $Acl = (Get-Item $driverPath).GetAccessControl('Access')
-    $Ar = New-Object  System.Security.AccessControl.FileSystemAccessRule("System", "Modify", "ContainerInherit, ObjectInherit", "None", "Deny")
-    $Acl.AddAccessRule($Ar)
-    Set-Acl $driverPath $Acl
-
-    If (Test-MitigationApplied) {
-        [array]$out += "SYSTEM permissions were successfully set to DENY on the driver folders for the spooler service."
+    If ($excludeFromMitigation -eq 1) {
+        Remove-Mitigation
+        $out += "This machine has been excluded from mitigation. Not restricting permissions on the spooler driver folder."
     } Else {
-        [array]$out += "There was a problem restricting permission on the spooler driver folder. Output: $($Error[0])"
+        $Acl = (Get-Item $driverPath).GetAccessControl('Access')
+        $Ar = New-Object  System.Security.AccessControl.FileSystemAccessRule("System", "Modify", "ContainerInherit, ObjectInherit", "None", "Deny")
+        $Acl.AddAccessRule($Ar)
+        Set-Acl $driverPath $Acl
+
+        If (Test-MitigationApplied) {
+            [array]$out += "SYSTEM permissions were successfully set to DENY on the driver folders for the spooler service."
+        } Else {
+            [array]$out += "There was a problem restricting permission on the spooler driver folder. Output: $($Error[0])"
+        }
     }
 
     <#
@@ -612,21 +616,6 @@ If ((Get-WMIObject win32_service -Filter "Name='spooler'").StartMode -eq 'Disabl
 
     # Exit Point
     Write-Output "outputLog=$($output -join '`n')|compatibleOs=$compatibleOs|originalPnpDisabledValue=$originalPnpDisabledValue|pnpVulnerableFeaturesDisabled=$pnpDisabled|mitigationApplied=0|patchApplied=$patchApplied|protected=1"
-    Return
-}
-
-# If $excludeFromMitigation is 1, don't mitigate. Exit early.
-If ($excludeFromMitigation -eq 1) {
-    $output += "This machine was excluded from mitigation"
-
-    If ($mitigationApplied -or ($patchApplied -and $pnpDisabled)) {
-        $protected = 1
-    } Else {
-        $protected = 0
-    }
-
-    # Exit Point
-    Write-Output "outputLog=$($output -join '`n')|compatibleOs=$compatibleOs|originalPnpDisabledValue=$originalPnpDisabledValue|pnpVulnerableFeaturesDisabled=$pnpDisabled|mitigationApplied=$mitigationApplied|patchApplied=$patchApplied|protected=$protected"
     Return
 }
 


### PR DESCRIPTION
Instead of exiting the script early on excludeFromMitigation, just don't apply ACL. We want everything else to perform the same way as usual, we ONLY don't want the ACL to apply