### PR TITLE
Adjusted all occurrences of `$mitigationApplied`

### DIFF
--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -640,7 +640,12 @@ If ((!$patchApplied -and $compatibleOs) -and $previousInstallAttempted) {
         $mitigationApplied = 1
         $compatibleOs = 0
     } Else {
-        $output += "Applying the ACL mitigation did not work for some reason."
+        If ($excludeFromMitigation) {
+            $output += "Did not apply mitigation as this machine has been excluded."
+        } Else {
+            $output += "Applying the ACL mitigation did not work for some reason."
+        }
+
         $protected = 0
         $mitigationApplied = 0
         $compatibleOs = 0
@@ -656,8 +661,14 @@ If ((!$patchApplied -and $compatibleOs) -and $previousInstallAttempted) {
 # there is no patch so we MUST have mitigation. Machine is protected in this case.
 If (!$compatibleOs) {
     $output += Apply-Mitigation
-    $mitigationApplied = 1
-    $protected = 1
+
+    If (Test-MitigationApplied) {
+        $mitigationApplied = 1
+        $protected = 1
+    } Else {
+        $mitigationApplied = 0
+        $protected = 0
+    }
 
     # Exit Point
     Write-Output "outputLog=$($output -join '`n')|compatibleOs=$compatibleOs|originalPnpDisabledValue=$originalPnpDisabledValue|pnpVulnerableFeaturesDisabled=$pnpDisabled|mitigationApplied=$mitigationApplied|patchApplied=$patchApplied|protected=$protected"
@@ -762,8 +773,14 @@ If ($patchApplied) {
 } Else {
     # Patch is still not installed so reapply mitigation
     $output += Apply-Mitigation
-    $mitigationApplied = 1
-    $protected = 1
+
+    If (Test-MitigationApplied) {
+        $mitigationApplied = 1
+        $protected = 1
+    } Else {
+        $mitigationApplied = 0
+        $protected = 0
+    }
 }
 
 Write-Output "outputLog=$($output -join '`n')|compatibleOs=$compatibleOs|originalPnpDisabledValue=$originalPnpDisabledValue|pnpVulnerableFeaturesDisabled=$pnpDisabled|mitigationApplied=$mitigationApplied|patchApplied=$patchApplied|protected=$protected|restrictDriverInstallation=$restrictDriverInstallation"


### PR DESCRIPTION
Adjusted all occurrences of `$mitigationApplied=1` to be inside of `If (Test-MitigationApplied)` blocks because with the recent changes, whether mitigation is applied or not depends on whether `$excludeFromMitigation` is true and not always which path we end up in.

Also adjusted output message about mitigation being applied so that it's not lying when `$excludeFromMitigation` is true.