### PR TITLE
Added KB5005101

### DIFF
--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -151,7 +151,8 @@ $2004AndNewerPatchKbs = @(
     'KB5004945',
     'KB5004237',
     'KB5004296',
-    'KB5005033'
+    'KB5005033',
+    'KB5005101'
 )
 
 $msDPath = 'http://download.windowsupdate.com/d/msdownload/update/software/secu'
@@ -319,7 +320,7 @@ Switch ($os) {
         $installHash = @{
             ssu =              $2004AndNewerSsuKb
             patchKBs =         $2004AndNewerPatchKbs
-            patchUrl =         "$msDPath/2021/08/windows10.0-kb5005033-x86_d5b969d54b3155cca9ad2e36565e1d8603aab21a.msu"
+            patchUrl =         "http://download.windowsupdate.com/d/msdownload/update/software/updt/2021/08/windows10.0-kb5005101-x86_75d4a61e9eaff4869f68ac8b8d2f081444241361.msu"
             ssuUrl =           "$msDPath/2021/08/ssu-19041.1161-x86_8c24024a060d03801fdc05a1dd06dcb874f3c847.msu"
         }
     }
@@ -327,7 +328,7 @@ Switch ($os) {
         $installHash = @{
             ssu =              $2004AndNewerSsuKb
             patchKBs =         $2004AndNewerPatchKbs
-            patchUrl =         "$msDPath/2021/08/windows10.0-kb5005033-x64_ebab415d7a65f0b33f93e9a30875d74baa8930a7.msu"
+            patchUrl =         "http://download.windowsupdate.com/c/msdownload/update/software/updt/2021/08/windows10.0-kb5005101-x64_dad841168de7aca6a2fc52b8938725128c7fef39.msu"
             ssuUrl =           "$msDPath/2021/08/ssu-19041.1161-x64_e7e052f5cbe97d708ee5f56a8b575262d02cfaa4.msu"
         }
     }
@@ -335,7 +336,7 @@ Switch ($os) {
         $installHash = @{
             ssu =              $2004AndNewerSsuKb
             patchKBs =         $2004AndNewerPatchKbs
-            patchUrl =         "$msDPath/2021/08/windows10.0-kb5005033-x86_d5b969d54b3155cca9ad2e36565e1d8603aab21a.msu"
+            patchUrl =         "http://download.windowsupdate.com/d/msdownload/update/software/updt/2021/08/windows10.0-kb5005101-x86_75d4a61e9eaff4869f68ac8b8d2f081444241361.msu"
             ssuUrl =           "$msDPath/2021/08/ssu-19041.1161-x86_8c24024a060d03801fdc05a1dd06dcb874f3c847.msu"
         }
     }
@@ -343,7 +344,7 @@ Switch ($os) {
         $installHash = @{
             ssu =              $2004AndNewerSsuKb
             patchKBs =         $2004AndNewerPatchKbs
-            patchUrl =         "$msDPath/2021/08/windows10.0-kb5005033-x64_ebab415d7a65f0b33f93e9a30875d74baa8930a7.msu"
+            patchUrl =         "http://download.windowsupdate.com/c/msdownload/update/software/updt/2021/08/windows10.0-kb5005101-x64_dad841168de7aca6a2fc52b8938725128c7fef39.msu"
             ssuUrl =           "$msDPath/2021/08/ssu-19041.1161-x64_e7e052f5cbe97d708ee5f56a8b575262d02cfaa4.msu"
         }
     }
@@ -351,7 +352,7 @@ Switch ($os) {
         $installHash = @{
             ssu =              $2004AndNewerSsuKb
             patchKBs =         $2004AndNewerPatchKbs
-            patchUrl =         "$msDPath/2021/08/windows10.0-kb5005033-x86_d5b969d54b3155cca9ad2e36565e1d8603aab21a.msu"
+            patchUrl =         "http://download.windowsupdate.com/d/msdownload/update/software/updt/2021/08/windows10.0-kb5005101-x86_75d4a61e9eaff4869f68ac8b8d2f081444241361.msu"
             ssuUrl =           "$msDPath/2021/08/ssu-19041.1161-x86_8c24024a060d03801fdc05a1dd06dcb874f3c847.msu"
         }
     }
@@ -359,7 +360,7 @@ Switch ($os) {
         $installHash = @{
             ssu =              $2004AndNewerSsuKb
             patchKBs =         $2004AndNewerPatchKbs
-            patchUrl =         "$msDPath/2021/08/windows10.0-kb5005033-x64_ebab415d7a65f0b33f93e9a30875d74baa8930a7.msu"
+            patchUrl =         "http://download.windowsupdate.com/c/msdownload/update/software/updt/2021/08/windows10.0-kb5005101-x64_dad841168de7aca6a2fc52b8938725128c7fef39.msu"
             ssuUrl =           "$msDPath/2021/08/ssu-19041.1161-x64_e7e052f5cbe97d708ee5f56a8b575262d02cfaa4.msu"
         }
     }


### PR DESCRIPTION
Uses the same SSU KB as the last patch. Hesitant to push to main until it's necessary though since it's not a security-only update... It does supersede the previous patch.. @wmmatt what do you think?