### PR TITLE
CVE 2021 40444

### DIFF
--- a/CVE-2021-40444/MITIGATION_CVE-2021-40444.ps1
+++ b/CVE-2021-40444/MITIGATION_CVE-2021-40444.ps1
@@ -1,0 +1,19 @@
+﻿$outputLog = @()
+
+$path = 'HKLM:\\\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones'
+$value = 0x00000003
+
+# Call in Registry-Helpers
+(New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/dkbrookie/PowershellFunctions/master/Function.Registry-Helpers.ps1') | Invoke-Expression
+
+Write-RegistryValue -Name '1001' -Path "$path\0" -Value $value -Type dword
+Write-RegistryValue -Name '1004' -Path "$path\0" -Value $value -Type dword
+
+Write-RegistryValue -Name '1001' -Path "$path\1" -Value $value -Type dword
+Write-RegistryValue -Name '1004' -Path "$path\1" -Value $value -Type dword
+
+Write-RegistryValue -Name '1001' -Path "$path\2" -Value $value -Type dword
+Write-RegistryValue -Name '1004' -Path "$path\2" -Value $value -Type dword
+
+Write-RegistryValue -Name '1001' -Path "$path\3" -Value $value -Type dword
+Write-RegistryValue -Name '1004' -Path "$path\3" -Value $value -Type dword

--- a/CVE-2021-40444/REMOVE_MITIGATION_CVE-2021-40444.ps1
+++ b/CVE-2021-40444/REMOVE_MITIGATION_CVE-2021-40444.ps1
@@ -1,0 +1,19 @@
+﻿$outputLog = @()
+
+$path = 'HKLM:\\\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones'
+$value = 0x00000003
+
+# Call in Registry-Helpers
+(New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/dkbrookie/PowershellFunctions/master/Function.Registry-Helpers.ps1') | Invoke-Expression
+
+Remove-RegistryValue -Name '1001' -Path "$path\0"
+Remove-RegistryValue -Name '1004' -Path "$path\0"
+
+Remove-RegistryValue -Name '1001' -Path "$path\1"
+Remove-RegistryValue -Name '1004' -Path "$path\1"
+
+Remove-RegistryValue -Name '1001' -Path "$path\2"
+Remove-RegistryValue -Name '1004' -Path "$path\2"
+
+Remove-RegistryValue -Name '1001' -Path "$path\3"
+Remove-RegistryValue -Name '1004' -Path "$path\3"


### PR DESCRIPTION
Don't know if this is needed yet, so leaving in draft status for the moment

Mitigation script and mitigation removal script. Mitigation script disables installation of activex controls in internet explorer by adding registry keys. Removal deletes those keys.

Probably should consider caching values in the case that the keys already exist and then replacing those original values in the event of removal. It is possible that some clients already have these configured in some way.