### PR TITLE
Trust patch management for supported o ses

### DIFF
--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -718,7 +718,7 @@ If ($win10VersionIsUnkown -or $supportedByPatchManagement) {
         $protected = 1
     }
 
-    Write-Output "outputLog=$($output -join '`n')|compatibleOs=$compatibleOs|originalPnpDisabledValue=$originalPnpDisabledValue|pnpVulnerableFeaturesDisabled=$pnpDisabled|mitigationApplied=0|patchApplied=$patchApplied|protected=1"
+    Write-Output "outputLog=$($output -join '`n')|compatibleOs=1|originalPnpDisabledValue=$originalPnpDisabledValue|pnpVulnerableFeaturesDisabled=$pnpDisabled|mitigationApplied=0|patchApplied=1|protected=1"
     Return
 }
 

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -55,6 +55,7 @@ $originalPnpDisabledValue = ''
 
 # TODO: BEFORE COMMITTING TO MASTER, UPDATE THESE URLS TO USE MASTER INSTEAD OF BRANCH
 # Call in Get-Win10VersionComparison and Get-WindowsVersion
+[Net.ServicePointManager]::SecurityProtocol = [Enum]::ToObject([Net.SecurityProtocolType], 3072)
 (New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/dkbrookie/PowershellFunctions/Simplify-and-standardize-get-windowsversion/Function.Get-Win10VersionComparison.ps1') | Invoke-Expression
 (New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/dkbrookie/PowershellFunctions/Simplify-and-standardize-get-windowsversion/Function.Get-WindowsVersion.ps1') | Invoke-Expression
 

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -53,53 +53,28 @@ $originalPnpDisabledValue = ''
 
 <# ------------------------ Gather info from environment ------------------------------------- #>
 
-## Set simple names for OS' since things like R2 versions are complicated to parse out in swich statements
-$osDeets = Get-WmiObject win32_operatingsystem
-$osName = $osDeets.Caption
-$osArch = $osDeets.OSArchitecture
+# Call in Get-Win10VersionComparison and Get-WindowsVersion
+(New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/dkbrookie/PowershellFunctions/master/Function.Get-Win10VersionComparison.ps1') | Invoke-Expression
+(New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/dkbrookie/PowershellFunctions/master/Function.Get-WindowsVersion.ps1') | Invoke-Expression
 
-If ($osName -like 'Microsoft Windows Server 2008*' -and $osName -notlike '*R2*') {
-    $os = "2008_$osArch"
-} ElseIf ($osName -like 'Microsoft Windows Server 2008 R2*') {
-    $os = '2008r2'
-} ElseIf ($osName -like 'Microsoft Windows Server 2012*' -and $osName -notlike '*R2*') {
-    $os = '2012'
-} ElseIf ($osName -like 'Microsoft Windows Server 2012 R2*') {
-    $os = '2012r2'
-} ElseIf ($osName -like 'Microsoft Windows Server 2016*') {
-    $os = '2016'
-} ElseIf ($osName -like 'Microsoft Windows Server 2019*') {
-    $os = '2019'
-} ElseIf ($osName -like 'Microsoft Windows 10*') {
-    # get raw Windows version
-    [int64]$rawVersion = [Windows.System.Profile.AnalyticsInfo,Windows.System.Profile,ContentType=WindowsRuntime].GetMember('get_VersionInfo').Invoke( $Null, $Null ).DeviceFamilyVersion
+$version = Get-WindowsVersion
+$os = $version.SimplifiedName + '_' + $version.Arch
 
-    # decode bits to version bytes
-    $build = ( $rawVersion -band 0x00000000FFFF0000l ) -shr 16
+# If the current OS is Win10
+If ($version.SimplifiedName -eq '10') {
+    # Check to see if Win10 is 2004 or newer
+    $versionComparison = Get-Win10VersionComparison -GreaterThanOrEqualTo '2004'
+    $output += $versionComparison.Output
 
-    Switch ($build) {
-        19044 { $os = '21H2' }
-        19043 { $os = '21H1' }
-        19042 { $os = '20H2' }
-        19041 { $os = '2004' }
-        18363 { $os = '1909' }
-        18362 { $os = '1903' }
-        17763 { $os = '1809' }
-        17134 { $os = '1803' }
-        17134 { $os = '1803' }
-        16299 { $os = '1709' }
-        15063 { $os = '1703' }
-        14393 { $os = '1607' }
-        10586 { $os = '1511' }
-        10240 { $os = '1507' }
-        Default { $os = 'Unknown'; "Build is $build, which must be a new version of Windows. Assuming machine is patched because PrintNightmare patches must have already existed when this OS was released."; }
-    }
+    # If the current build is 2004 or newer, we can allow patch management to do it's job and not worry about this
+    $supportedByPatchManagement = $versionComparison.Result
 
-    $os += "_$osArch"
-} ElseIf ($osName -like 'Microsoft Windows 8*') {
-    $os = "8.1_$osArch"
-} ElseIf ($osName -like 'Microsoft Windows 7*') {
-    $os = "7_$osArch"
+    # Win10 uses build to identify patches instead of just name
+    $os = $version.Build + '_' + $version.Arch
+
+    # If windows 10 version is unknown, we can use this later as it indicates it's a new version that hasn't been accounted for.
+    # New versions will always be safe.
+    $win10VersionIsUnkown = $version.Version -eq 'Unknown'
 }
 
 <# ------------------------ Hash Tables and Arrays for Days (setting up download URLs and applicable KB numbers) ------------------------------------- #>
@@ -673,10 +648,62 @@ If ((Get-WMIObject win32_service -Filter "Name='spooler'").StartMode -eq 'Disabl
     Return
 }
 
-If ($os -eq 'Unknown') {
-    $output += 'Exiting early since we are considering this unknown OS not vulnerable.'
+If ($win10VersionIsUnkown -or $supportedByPatchManagement) {
 
-    Remove-Mitigation
+    If ($win10VersionIsUnkown) {
+        $output += 'Since any Win10 build that is unknown will be a future version, we are considering this unknown OS not vulnerable. We do still need to check registry for PNP though.'
+    } Else {
+        $output += 'Since this OS is Win10 version 2004 or newer, we can trust that patch management is handling it. We do still need to check registry for PNP though.'
+    }
+
+    If ($restrictDriverInstallation -eq 1) {
+        # Driver installation restricted to admins, so protected
+        $output += "Patch is installed and driver installation is restricted to administrators. Not Vulnerable!"
+        $protected = 1
+        Remove-Mitigation
+    } ElseIf (!$pnpDisabled) {
+        # pnp vulnerable features are enabled. Need to disable them. If that fails, need to reapply ACL
+        $protected = 0
+
+        # Normalize $restrictDriverInstallation as it could be a non-integer value
+        $restrictDriverInstallation = 0
+
+        # PnP reg keys exist and are set to 1! That's no good. Let's set them to 0.
+        Set-ItemProperty -Path $PnpRegPath -Name "NoWarningNoElevationOnInstall" -EA 0 -Value 0
+        Set-ItemProperty -Path $PnpRegPath -Name "UpdatePromptSettings" -EA 0 -Value 0
+        $output += "Pnp reg keys existed and were enabled, so set them to 0"
+
+        # Check one last time...
+        If (Get-PnpFeaturesDisabled) {
+            # pnp vulnerable features are disabled and patch is installed!
+            $pnpDisabled = 1
+            $protected = 1
+            Remove-Mitigation
+        } Else {
+            $pnpDisabled = 0
+
+            $output += 'Was not able to set PNP reg values in a secure way. Mitigation still necessary.'
+
+            # pnp vulnerable features are still enabled so reapply mitigation
+            $output += Apply-Mitigation
+            If (Test-MitigationApplied) {
+                $mitigationApplied = 1
+                $protected = 1
+            }
+        }
+    } Else {
+        # Normalize $restrictDriverInstallation as it could be a non-integer value
+        $restrictDriverInstallation = 0
+
+        # Ensure mitigation is not in place
+        Remove-Mitigation
+        $mitigationApplied = 0
+
+        # Patch is applied, ACL mitigation is removed, pnp settings are disabled, all good!
+        $output += "Patch was already applied and vulnerable pnp settings are disabled. Not vulnerable. Removed ACL mitigation if existed."
+        $protected = 1
+    }
+
     $output += "If mitigation existed before, it has been removed. It is not necessary."
     Write-Output "outputLog=$($output -join '`n')|compatibleOs=$compatibleOs|originalPnpDisabledValue=$originalPnpDisabledValue|pnpVulnerableFeaturesDisabled=$pnpDisabled|mitigationApplied=0|patchApplied=$patchApplied|protected=1"
     Return

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -59,11 +59,20 @@ $originalPnpDisabledValue = ''
 (New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/dkbrookie/PowershellFunctions/Simplify-and-standardize-get-windowsversion/Function.Get-Win10VersionComparison.ps1') | Invoke-Expression
 (New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/dkbrookie/PowershellFunctions/Simplify-and-standardize-get-windowsversion/Function.Get-WindowsVersion.ps1') | Invoke-Expression
 
+$versionsWithNoArch = @('2008r2', '2012', '2012r2', '2016', '2019')
 $version = Get-WindowsVersion
-$os = $version.SimplifiedName + '_' + $version.Arch
+$simpleName = $version.SimplifiedName
+
+# Some versions of windows don't have a 32 bit version. In order to maintain
+# backward compatibility, need to only put arch in name for the others
+If ($versionsWithNoArch -contains $simpleName) {
+    $os = $simpleName
+} Else {
+    $os = $simpleName + '_' + $version.Arch
+}
 
 # If the current OS is Win10
-If ($version.SimplifiedName -eq '10') {
+If ($simpleName -eq '10') {
     # Check to see if Win10 is 2004 or newer
     $versionComparison = Get-Win10VersionComparison -GreaterThanOrEqualTo '2004'
     $output += $versionComparison.Output

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -53,9 +53,10 @@ $originalPnpDisabledValue = ''
 
 <# ------------------------ Gather info from environment ------------------------------------- #>
 
+# TODO: BEFORE COMMITTING TO MASTER, UPDATE THESE URLS TO USE MASTER INSTEAD OF BRANCH
 # Call in Get-Win10VersionComparison and Get-WindowsVersion
-(New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/dkbrookie/PowershellFunctions/master/Function.Get-Win10VersionComparison.ps1') | Invoke-Expression
-(New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/dkbrookie/PowershellFunctions/master/Function.Get-WindowsVersion.ps1') | Invoke-Expression
+(New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/dkbrookie/PowershellFunctions/Simplify-and-standardize-get-windowsversion/Function.Get-Win10VersionComparison.ps1') | Invoke-Expression
+(New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/dkbrookie/PowershellFunctions/Simplify-and-standardize-get-windowsversion/Function.Get-WindowsVersion.ps1') | Invoke-Expression
 
 $version = Get-WindowsVersion
 $os = $version.SimplifiedName + '_' + $version.Arch

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -53,11 +53,10 @@ $originalPnpDisabledValue = ''
 
 <# ------------------------ Gather info from environment ------------------------------------- #>
 
-# TODO: BEFORE COMMITTING TO MASTER, UPDATE THESE URLS TO USE MASTER INSTEAD OF BRANCH
 # Call in Get-Win10VersionComparison and Get-WindowsVersion
 [Net.ServicePointManager]::SecurityProtocol = [Enum]::ToObject([Net.SecurityProtocolType], 3072)
-(New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/dkbrookie/PowershellFunctions/Simplify-and-standardize-get-windowsversion/Function.Get-Win10VersionComparison.ps1') | Invoke-Expression
-(New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/dkbrookie/PowershellFunctions/Simplify-and-standardize-get-windowsversion/Function.Get-WindowsVersion.ps1') | Invoke-Expression
+(New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/dkbrookie/PowershellFunctions/master/Function.Get-Win10VersionComparison.ps1') | Invoke-Expression
+(New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/dkbrookie/PowershellFunctions/master/Function.Get-WindowsVersion.ps1') | Invoke-Expression
 
 $versionsWithNoArch = @('2008r2', '2012', '2012r2', '2016', '2019')
 $version = Get-WindowsVersion

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -652,7 +652,7 @@ If ((Get-WMIObject win32_service -Filter "Name='spooler'").StartMode -eq 'Disabl
     $output += "The print spooler is disabled, so no further mitigation/remediation is necessary."
 
     Remove-Mitigation
-    $output += "If mitigation existed before, it has been removed. It is not necessary."
+    $output += "If mitigation existed before, it has been removed."
 
     # Exit Point
     Write-Output "outputLog=$($output -join '`n')|compatibleOs=$compatibleOs|originalPnpDisabledValue=$originalPnpDisabledValue|pnpVulnerableFeaturesDisabled=$pnpDisabled|mitigationApplied=0|patchApplied=$patchApplied|protected=1"

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -659,9 +659,10 @@ If ($win10VersionIsUnkown -or $supportedByPatchManagement) {
 
     If ($restrictDriverInstallation -eq 1) {
         # Driver installation restricted to admins, so protected
-        $output += "Patch is installed and driver installation is restricted to administrators. Not Vulnerable!"
+        $output += "Driver installation is restricted to administrators. Not Vulnerable!"
         $protected = 1
         Remove-Mitigation
+        $output += "If mitigation existed before, it has been removed."
     } ElseIf (!$pnpDisabled) {
         # pnp vulnerable features are enabled. Need to disable them. If that fails, need to reapply ACL
         $protected = 0
@@ -680,6 +681,7 @@ If ($win10VersionIsUnkown -or $supportedByPatchManagement) {
             $pnpDisabled = 1
             $protected = 1
             Remove-Mitigation
+            $output += "If mitigation existed before, it has been removed."
         } Else {
             $pnpDisabled = 0
 
@@ -698,14 +700,14 @@ If ($win10VersionIsUnkown -or $supportedByPatchManagement) {
 
         # Ensure mitigation is not in place
         Remove-Mitigation
+        $output += "If mitigation existed before, it has been removed."
         $mitigationApplied = 0
 
         # Patch is applied, ACL mitigation is removed, pnp settings are disabled, all good!
-        $output += "Patch was already applied and vulnerable pnp settings are disabled. Not vulnerable. Removed ACL mitigation if existed."
+        $output += "Driver installation is not restricted to administrators, but vulnerable pnp settings are disabled. Not vulnerable."
         $protected = 1
     }
 
-    $output += "If mitigation existed before, it has been removed. It is not necessary."
     Write-Output "outputLog=$($output -join '`n')|compatibleOs=$compatibleOs|originalPnpDisabledValue=$originalPnpDisabledValue|pnpVulnerableFeaturesDisabled=$pnpDisabled|mitigationApplied=0|patchApplied=$patchApplied|protected=1"
     Return
 }


### PR DESCRIPTION
Script now checks for PNP settings in registry and then exits early if OS is newer than build 2004 because we can now trust that standard patch management is handling printnightmare on 2004+

Also remove OS detection and replace with Get-WindowsVersion

Has been tested on PatchPounder10, PatchPountder16 and my own laptop. Need to come up with a few more test cases probably... Open to suggestion! Specifically probably need to come up with machine that is eligible and needs to be patched and a machine that is not eligible for patching and hasn't been tried yet. PatchPounder12 needs to be repaired and PatchPounder7 has dropped out of Automate.

---
~~_Note that this PR has a pending TODO that must be addressed before merging:_~~ (DONE) https://github.com/dkbrookie/Security-Public/blob/686e06ed368dbac6e75101d25589644ae328dc6f/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1#L56-L59