### PR TITLE
Extend unknown version handling to all oses

### DIFF
--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -81,11 +81,11 @@ If ($simpleName -eq '10') {
 
     # Win10 uses build to identify patches instead of just name
     $os = $version.Build + '_' + $version.Arch
-
-    # If windows 10 version is unknown, we can use this later as it indicates it's a new version that hasn't been accounted for.
-    # New versions will always be safe.
-    $win10VersionIsUnkown = $version.Version -eq 'Unknown'
 }
+
+# If windows version is unknown, we can use this later as it indicates it's a new version that hasn't been accounted for.
+# New versions will always be safe.
+$versionIsUnknown = $version.Version -eq 'Unknown'
 
 <# ------------------------ Hash Tables and Arrays for Days (setting up download URLs and applicable KB numbers) ------------------------------------- #>
 
@@ -404,6 +404,9 @@ Switch ($os) {
         }
     }
     Default {
+        $output += "This OS does not appear to have any defined patches. Assuming that this is a new OS and is covered by patch management. The OS is $os."
+        $versionIsUnknown = $true
+
         $installHash = @{
             patchKBs = @()
             patchUrl = $Null
@@ -658,10 +661,10 @@ If ((Get-WMIObject win32_service -Filter "Name='spooler'").StartMode -eq 'Disabl
     Return
 }
 
-If ($win10VersionIsUnkown -or $supportedByPatchManagement) {
+If ($versionIsUnknown -or $supportedByPatchManagement) {
 
-    If ($win10VersionIsUnkown) {
-        $output += 'Since any Win10 build that is unknown will be a future version, we are considering this unknown OS not vulnerable. We do still need to check registry for PNP though.'
+    If ($versionIsUnknown) {
+        $output += 'Since any Windows build that is unknown will be a future version, we are considering this unknown OS not vulnerable. We do still need to check registry for PNP though.'
     } Else {
         $output += 'Since this OS is Win10 version 2004 or newer, we can trust that patch management is handling it. We do still need to check registry for PNP though.'
     }

--- a/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
+++ b/CVE-2021-34527_PrintNightmare/CVE-2021_34527_PrintNightmare_Patch.ps1
@@ -72,12 +72,17 @@ If ($versionsWithNoArch -contains $simpleName) {
 
 # If the current OS is Win10
 If ($simpleName -eq '10') {
-    # Check to see if Win10 is 2004 or newer
-    $versionComparison = Get-Win10VersionComparison -GreaterThanOrEqualTo '2004'
-    $output += $versionComparison.Output
+    # Get-Win10VersionComparison could Throw if OS is unknown
+    Try {
+        # Check to see if Win10 is 2004 or newer
+        $versionComparison = Get-Win10VersionComparison -GreaterThanOrEqualTo '2004'
+        $output += $versionComparison.Output
 
-    # If the current build is 2004 or newer, we can allow patch management to do it's job and not worry about this
-    $supportedByPatchManagement = $versionComparison.Result
+        # If the current build is 2004 or newer, we can allow patch management to do it's job and not worry about this
+        $supportedByPatchManagement = $versionComparison.Result
+    } Catch {
+        $output += "Get-Win1-VersionComparison threw an error. The error was: $_."
+    }
 
     # Win10 uses build to identify patches instead of just name
     $os = $version.Build + '_' + $version.Arch


### PR DESCRIPTION
generalize win10 specific unknown OS handling and catch error that `Get-Win10VersionComparison` might throw if OS is unknown.